### PR TITLE
add mounts for the other indexes we say we have in the code

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -330,8 +330,19 @@ function(
                         {
                             name: fullyQualifiedName + '-api',
                             image: apiImage,
+                            // TODO: point these to the actual indexes
                             volumeMounts: [{
-                                mountPath: "/mnt/infinigram-array",
+                                mountPath: "/mnt/infinigram-array/v4_pileval_llama",
+                                name: "infinigram-array",
+                                readOnly: true,
+                            },
+                            {
+                                mountPath: "/mnt/infinigram-array/dolma_1_6_sample",
+                                name: "infinigram-array",
+                                readOnly: true,
+                            }, 
+                            {
+                                mountPath: "/mnt/infinigram-array/dolma_1_7",
                                 name: "infinigram-array",
                                 readOnly: true,
                             }],


### PR DESCRIPTION
Temporary fix to allow infinigram-api to deploy without actually making the disks for other indexes yet