### PR TITLE
[OEUI-60] [OEUI-47] move documents endpoints to another router

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -3,7 +3,9 @@ import os
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+
 from src import glog
+from src.documents import documents_router
 from src.health import health_router
 from src.infinigram import infinigram_router
 from src.infinigram.infini_gram_engine_exception import InfiniGramEngineException
@@ -15,9 +17,10 @@ handlers = [glog.Handler()] if fmt == "google:json" else []
 level = os.environ.get("LOG_LEVEL", default=logging.INFO)
 logging.basicConfig(level=level, handlers=handlers)
 
-app = FastAPI()
+app = FastAPI(title="infini-gram API", version="0.0.1")
 app.include_router(health_router)
 app.include_router(router=infinigram_router)
+app.include_router(router=documents_router)
 
 
 @app.exception_handler(InfiniGramEngineException)

--- a/api/src/documents/__init__.py
+++ b/api/src/documents/__init__.py
@@ -1,0 +1,1 @@
+from src.documents.documents_router import documents_router as documents_router

--- a/api/src/documents/documents_router.py
+++ b/api/src/documents/documents_router.py
@@ -1,0 +1,48 @@
+from typing import Annotated, TypeAlias
+
+from fastapi import APIRouter, Query
+
+from src.infinigram.processor import (
+    InfiniGramDocumentsResponse,
+    InfiniGramProcessorDependency,
+    InfiniGramRankResponse,
+)
+
+documents_router = APIRouter()
+
+MaximumDocumentDisplayLengthType: TypeAlias = Annotated[
+    int,
+    Query(
+        title="The maximum length in tokens of the returned document text",
+        gt=0,
+    ),
+]
+
+
+@documents_router.get("/{index}/documents/{shard}/{rank}", tags=["documents"])
+def get_document_by_rank(
+    shard: int,
+    rank: int,
+    infini_gram_processor: InfiniGramProcessorDependency,
+    maximum_document_display_length: MaximumDocumentDisplayLengthType = 10,
+) -> InfiniGramRankResponse:
+    result = infini_gram_processor.get_document_by_rank(
+        shard=shard,
+        rank=rank,
+        maximum_document_display_length=maximum_document_display_length,
+    )
+
+    return result
+
+
+@documents_router.get("/{index}/documents/", tags=["documents"])
+def search_documents(
+    infini_gram_processor: InfiniGramProcessorDependency,
+    search: str,
+    maximum_document_display_length: MaximumDocumentDisplayLengthType = 10,
+) -> InfiniGramDocumentsResponse:
+    result = infini_gram_processor.search_documents(
+        search, maximum_document_display_length=maximum_document_display_length
+    )
+
+    return result

--- a/api/src/infinigram/infinigram_router.py
+++ b/api/src/infinigram/infinigram_router.py
@@ -9,10 +9,7 @@ from src.infinigram.processor import (
     InfiniGramAttributionResponse,
     InfiniGramAttributionResponseWithDocs,
     InfiniGramCountResponse,
-    InfiniGramDocumentsResponse,
     InfiniGramProcessorDependency,
-    InfiniGramQueryResponse,
-    InfiniGramRankResponse,
 )
 
 infinigram_router = APIRouter()
@@ -23,19 +20,7 @@ def get_available_indexes() -> list[AvailableInfiniGramIndexId]:
     return [index for index in AvailableInfiniGramIndexId]
 
 
-@infinigram_router.post("/{index}/query")
-def query(
-    query: Annotated[
-        str, Body(examples=["Seattle", "Economic Growth", "Linda Tuhiwai Smith"])
-    ],
-    infini_gram_processor: InfiniGramProcessorDependency,
-) -> InfiniGramQueryResponse:
-    result = infini_gram_processor.find_docs_with_query(query=query)
-
-    return result
-
-
-@infinigram_router.post("/{index}/count")
+@infinigram_router.get("/{index}/count")
 def count(
     query: Annotated[str, Body(examples=["Seattle"])],
     infini_gram_processor: InfiniGramProcessorDependency,
@@ -45,37 +30,35 @@ def count(
     return result
 
 
-@infinigram_router.get("/{index}/documents/{shard}/{rank}")
-def rank(
-    shard: int,
-    rank: int,
-    infini_gram_processor: InfiniGramProcessorDependency,
-) -> InfiniGramRankResponse:
-    result = infini_gram_processor.rank(shard=shard, rank=rank)
-
-    return result
-
-
-@infinigram_router.get("/{index}/documents/")
-def get_documents(
-    infini_gram_processor: InfiniGramProcessorDependency,
-    search: str,
-) -> InfiniGramDocumentsResponse:
-    result = infini_gram_processor.get_documents(search)
-
-    return result
-
-
 EXAMPLE_ATTRIBUTION_QUERY = "Hailing a taxi in Rome is fairly easy. Expect to pay around EUR 10-15 (approx. $11.29 - $15.58) to most tourist spots. Tipping isn't common in Italy, but round up the taxi fare or leave a small tip in the event of exceptional service. car rental is an alternative, but traffic in Rome can be daunting for newbies. If you decide to rent a car, make sure you're comfortable navigating busy medieval streets."
 
 
 class AttributionRequest(CamelCaseModel):
     query: str = Field(examples=[EXAMPLE_ATTRIBUTION_QUERY])
-    delimiters: List[str] = Field(examples=[["\n", "."]], default=[])
-    minimum_span_length: int = Field(gt=0, default=5)
-    maximum_frequency: int = Field(gt=0, default=10)
-    include_documents: bool = False
-    maximum_document_display_length: int = Field(gt=0, default=100)
+    delimiters: List[str] = Field(
+        examples=[["\n", "."]],
+        default=[],
+        description="Token IDs that returned spans shouldn't include",
+    )
+    minimum_span_length: int = Field(
+        gt=0,
+        default=5,
+        description='The minimum length to qualify an n-gram span as "interesting"',
+    )
+    maximum_frequency: int = Field(
+        gt=0,
+        default=10,
+        description='The maximum frequency that an n-gram span can have in an index for us to consider it as "interesting"',
+    )
+    include_documents: bool = Field(
+        default=False,
+        description="Set this to True if you want to have the response include referenced documents along with the spans",
+    )
+    maximum_document_display_length: int = Field(
+        gt=0,
+        default=100,
+        description="The maximum length in tokens of the returned document text",
+    )
 
 
 @infinigram_router.post(path="/{index}/attribution")


### PR DESCRIPTION
Closes [OEUI-60](https://allenai.atlassian.net/browse/OEUI-60) and OEUI-47

This PR moves things related to getting and searching documents to another router. This will hopefully help keep things organized in the future! 

It also adds more documentation to the API docs.

![image](https://github.com/user-attachments/assets/fc9c40bd-c804-43bb-a2a3-6c4b7ee695c3)
![image](https://github.com/user-attachments/assets/0f03f850-7f42-45e6-864a-85510154c0f8)


[OEUI-60]: https://allenai.atlassian.net/browse/OEUI-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ