### PR TITLE
fix olmoe-mix pv and pvc

### DIFF
--- a/volume-claims/olmoe-mix-0924.yaml
+++ b/volume-claims/olmoe-mix-0924.yaml
@@ -7,7 +7,7 @@ spec:
   capacity:
     storage: 39Ti
   accessModes:
-    - ReadWriteOnce
+    - ReadOnlyMany
   claimRef:
     namespace: infinigram-api
     name: infinigram-olmoe-mix-0924
@@ -15,6 +15,7 @@ spec:
     driver: pd.csi.storage.gke.io
     volumeHandle: projects/ai2-reviz/zones/us-west1-b/disks/infini-gram-olmoe-mix-0924
     fsType: ext4
+    readOnly: true
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -25,7 +26,7 @@ spec:
   storageClassName: "infinigram"
   volumeName: infinigram-olmoe-mix-0924
   accessModes:
-    - ReadWriteOnce
+    - ReadOnlyMany
   resources:
     requests:
       storage: 39Ti


### PR DESCRIPTION
I forgot to make the olmoe-mix pv and pvc readonly. it's fixed in k8s but this pr adds them to the repo too.