### PR TITLE
Add index for OLMo 2

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -356,6 +356,13 @@ function(
                         }
                     },
                     {
+                        name: "infinigram-array-v4-olmo-2-1124-13b-anneal-adapt",
+                        persistentVolumeClaim: {
+                            claimName: "infinigram-v4-olmo-2-1124-13b-anneal-adapt",
+                            readOnly: true,
+                        }
+                    },
+                    {
                         name: "infinigram-array-dolma-1-7-llama",
                         persistentVolumeClaim: {
                             claimName: "infinigram-dolma-1.7-llama",
@@ -394,6 +401,11 @@ function(
                             {
                                 mountPath: "/mnt/infinigram-array/v4-tulu-v3-1-mix",
                                 name: "infinigram-array-v4-tulu-v3-1-mix",
+                                readOnly: true,
+                            },
+                            {
+                                mountPath: "/mnt/infinigram-array/v4-olmo-2-1124-13b-anneal-adapt",
+                                name: "infinigram-array-v4-olmo-2-1124-13b-anneal-adapt",
                                 readOnly: true,
                             }],
                             # The "probes" below allow Kubernetes to determine

--- a/api/src/infinigram/index_mappings.py
+++ b/api/src/infinigram/index_mappings.py
@@ -8,10 +8,11 @@ from .tokenizers.tokenizer_factory import get_llama_2_tokenizer
 
 
 class AvailableInfiniGramIndexId(Enum):
-    DOLMA_1_7 = "dolma-1_7"
     PILEVAL_LLAMA = "pileval-llama"
+    DOLMA_1_7 = "dolma-1_7"
     OLMOE_MIX_0924 = "olmoe-mix-0924"
     OLMOE = "olmoe"
+    OLMO_2_1124_13B = "olmo-2-1124-13b"
 
 
 class IndexMapping(TypedDict):
@@ -26,6 +27,7 @@ IndexMappings = TypedDict(
         "dolma-1_7": IndexMapping,
         "olmoe-mix-0924": IndexMapping,
         "olmoe": IndexMapping,
+        "olmo-2-1124-13b": IndexMapping,
     },
 )
 
@@ -52,6 +54,14 @@ index_mappings: IndexMappings = {
             f"{config.index_base_path}/olmoe-mix-0924-nodclm",
             f"{config.index_base_path}/v4-tulu-v3-1-mix",
             f"{config.index_base_path}/v4-ultrafeedback",
+        ],
+    },
+    AvailableInfiniGramIndexId.OLMO_2_1124_13B.value: {
+        "tokenizer": get_llama_2_tokenizer(),
+        "index_dir": [
+            f"{config.index_base_path}/olmoe-mix-0924-dclm",
+            f"{config.index_base_path}/olmoe-mix-0924-nodclm",
+            f"{config.index_base_path}/v4-olmo-2-1124-13b-anneal-adapt",
         ],
     },
 }

--- a/bin/download-infini-gram-array.sh
+++ b/bin/download-infini-gram-array.sh
@@ -15,9 +15,14 @@ if [ ! -d $INFINIGRAM_ARRAY_DIR/dolma_1_7 ]; then
     ln -s $INFINIGRAM_ARRAY_DIR/v4_pileval_llama $INFINIGRAM_ARRAY_DIR/dolma_1_7
 fi
 
-if [ ! -d $INFINIGRAM_ARRAY_DIR/olmoe-mix-0924 ]; then
-    echo "creating a link from v4_pileval_llama to olmoe-mix-0924"
-    ln -s $INFINIGRAM_ARRAY_DIR/v4_pileval_llama $INFINIGRAM_ARRAY_DIR/olmoe-mix-0924
+if [ ! -d $INFINIGRAM_ARRAY_DIR/olmoe-mix-0924-dclm ]; then
+    echo "creating a link from v4_pileval_llama to olmoe-mix-0924-dclm"
+    ln -s $INFINIGRAM_ARRAY_DIR/v4_pileval_llama $INFINIGRAM_ARRAY_DIR/olmoe-mix-0924-dclm
+fi
+
+if [ ! -d $INFINIGRAM_ARRAY_DIR/olmoe-mix-0924-nodclm ]; then
+    echo "creating a link from v4_pileval_llama to olmoe-mix-0924-nodclm"
+    ln -s $INFINIGRAM_ARRAY_DIR/v4_pileval_llama $INFINIGRAM_ARRAY_DIR/olmoe-mix-0924-nodclm
 fi
 
 if [ ! -d $INFINIGRAM_ARRAY_DIR/v4-ultrafeedback ]; then
@@ -28,4 +33,9 @@ fi
 if [ ! -d $INFINIGRAM_ARRAY_DIR/v4-tulu-v3-1-mix ]; then
     echo "creating a link from v4_pileval_llama to v4-tulu-v3-1-mix"
     ln -s $INFINIGRAM_ARRAY_DIR/v4_pileval_llama $INFINIGRAM_ARRAY_DIR/v4-tulu-v3-1-mix
+fi
+
+if [ ! -d $INFINIGRAM_ARRAY_DIR/v4-olmo-2-1124-13b-anneal-adapt ]; then
+    echo "creating a link from v4_pileval_llama to v4-olmo-2-1124-13b-anneal-adapt"
+    ln -s $INFINIGRAM_ARRAY_DIR/v4_pileval_llama $INFINIGRAM_ARRAY_DIR/v4-olmo-2-1124-13b-anneal-adapt
 fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
       - ./infinigram-array/olmoe-mix-0924-nodclm:/mnt/infinigram-array/olmoe-mix-0924-nodclm
       - ./infinigram-array/v4-ultrafeedback:/mnt/infinigram-array/v4-ultrafeedback
       - ./infinigram-array/v4-tulu-v3-1-mix:/mnt/infinigram-array/v4-tulu-v3-1-mix
+      - ./infinigram-array/v4-olmo-2-1124-13b-anneal-adapt:/mnt/infinigram-array/v4-olmo-2-1124-13b-anneal-adapt
     environment:
       # This ensures that errors are printed as they occur, which
       # makes debugging easier.

--- a/volume-claims/v4-olmo-2-1124-13b-anneal-adapt.yaml
+++ b/volume-claims/v4-olmo-2-1124-13b-anneal-adapt.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: infinigram-v4-olmo-2-1124-13b-anneal-adapt
+spec:
+  storageClassName: "infinigram"
+  capacity:
+    storage: 300Gi
+  accessModes:
+    - ReadOnlyMany
+  claimRef:
+    namespace: infinigram-api
+    name: infinigram-v4-olmo-2-1124-13b-anneal-adapt
+  csi:
+    driver: pd.csi.storage.gke.io
+    volumeHandle: projects/ai2-reviz/zones/us-west1-b/disks/$DISK_NAME
+    fsType: ext4
+    readOnly: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: infinigram-api
+  name: infinigram-v4-olmo-2-1124-13b-anneal-adapt
+spec:
+  storageClassName: "infinigram"
+  volumeName: infinigram-v4-olmo-2-1124-13b-anneal-adapt
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 300Gi


### PR DESCRIPTION
Following the changes in https://github.com/allenai/infinigram-api/pull/48

Land this after new index files have been transferred to GCP

@mtblanton Can you transfer the index from S3 to GCP? The S3 path is `s3://infini-gram/index/v4_olmo-2-1124-13b-anneal-adapt_llama/`, and I named the path on GCP as `v4-olmo-2-1124-13b-anneal-adapt`