### PR TITLE
add workers == number of vcpus

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -26,4 +26,4 @@ CMD ["fastapi", "dev", "app.py", "--port", "8000", "--proxy-headers", "--host", 
 
 FROM builder as prod
 
-CMD ["fastapi", "run", "app.py", "--port", "8000", "--proxy-headers"]
+CMD ["fastapi", "run", "app.py", "--port", "8000", "--proxy-headers", "--workers", "14"]


### PR DESCRIPTION
We currently only have one worker in prod. During the bug bash today we were seeing a lot of health check issues where it wasn't responding. Since we only have two pods at all times and we don't auto-scale through K8s we should _probably_ use workers. If we start auto-scaling this API we'll want to reconsider this.

Adding more workers _should_ allow the API to handle more requests at a time, hopefully allowing more requests to go through faster. We'll want to keep an eye on how the API behaves under load with this change.

Tested this locally and didn't run into any issues. We'll need to test under load to really see what's up!