### PR TITLE
log infini-gram errors in the error handler

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -33,6 +33,10 @@ register_profiling_middleware(app)
 def infini_gram_engine_exception_handler(
     request: Request, exception: InfiniGramEngineException
 ) -> JSONResponse:
+    logger = logging.getLogger(__name__)
+
+    logger.error(f"infini-gram engine exception: {exception}")
+
     response = RFC9457Error(
         title="infini-gram error",
         status=500,


### PR DESCRIPTION
We weren't getting logs for infini-gram errors during the bug bash today. This isn't perfect, but it should give us something to work off of!

![image](https://github.com/user-attachments/assets/1cb9f5d7-c091-46b4-8de6-cca54558cdb1)
