### PR TITLE
use 14 workers in prod

### DIFF
--- a/api/src/infinigram/processor.py
+++ b/api/src/infinigram/processor.py
@@ -102,7 +102,7 @@ class InfiniGramProcessor:
             index_dir=index_mapping["index_dir"],
             eos_token_id=self.tokenizer.eos_token_id,
             bow_ids_path=self.tokenizer.bow_ids_path,
-            precompute_unigram_logprobs=False,
+            precompute_unigram_logprobs=True,
             # for the attribution feature, disabling prefetching on ds and sa can speed things up
             ds_prefetch_depth=0,
             sa_prefetch_depth=0,


### PR DESCRIPTION
With the changes @liujch1998 made to unigram computation caching we can now run parallel workers! Tested this with https://infinigram-api-switch-workers-2.apps.allenai.org/docs#/default/get_document_attributions__index__attribution_post and it seems to be working well.

This should allow this API to handle more load.