### PR TITLE
put workers back to 1 to help debug 502s

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -26,4 +26,4 @@ CMD ["fastapi", "dev", "app.py", "--port", "8000", "--proxy-headers", "--host", 
 
 FROM builder as prod
 
-CMD ["fastapi", "run", "app.py", "--port", "8000", "--proxy-headers", "--workers", "1"]
+CMD ["fastapi", "run", "app.py", "--port", "8000", "--proxy-headers"]


### PR DESCRIPTION
we're seeing an occassional 502 on long responses. We're putting the workers back to 1 so we can debug if this is a workers problem or an engine problem

Example message with a 502: https://dev.olmo-ui.allen.ai/thread/msg_H2M1V6K0R1?isCorpusLinkEnabled=true