### PR TITLE
Do not return CL results when keyword lyric is in the prompt

### DIFF
--- a/api/src/attribution/attribution_router.py
+++ b/api/src/attribution/attribution_router.py
@@ -4,13 +4,13 @@ from fastapi import APIRouter, Depends
 from pydantic import Field
 
 from src.infinigram.processor import (
-    InfiniGramErrorResponse,
     SpanRankingMethod,
 )
 from src.attribution.attribution_service import (
     AttributionService,
     FilterMethod,
     FieldsConsideredForRanking,
+    InfiniGramAttributionErrorResponse,
     InfiniGramAttributionResponse,
     InfiniGramAttributionResponseWithDocuments,
 )
@@ -105,7 +105,7 @@ class AttributionRequest(CamelCaseModel):
 def get_document_attributions(
     body: AttributionRequest,
     attribution_service: Annotated[AttributionService, Depends()],
-) -> InfiniGramAttributionResponse | InfiniGramAttributionResponseWithDocuments | InfiniGramErrorResponse:
+) -> InfiniGramAttributionResponse | InfiniGramAttributionResponseWithDocuments | InfiniGramAttributionErrorResponse:
     result = attribution_service.get_attribution_for_response(
         prompt=body.prompt,
         response=body.response,

--- a/api/src/attribution/attribution_service.py
+++ b/api/src/attribution/attribution_service.py
@@ -17,7 +17,6 @@ from src.infinigram.processor import (
     SpanRankingMethod,
     BaseInfiniGramResponse,
     DocumentWithPointer,
-    InfiniGramErrorResponse,
     InfiniGramProcessor,
     InfiniGramProcessorDependency,
 )
@@ -82,6 +81,10 @@ class InfiniGramAttributionResponseWithDocuments(
 ): ...
 
 
+class InfiniGramAttributionErrorResponse(BaseInfiniGramResponse):
+    error: str
+
+
 class AttributionService:
     infini_gram_processor: InfiniGramProcessor
     documents_service: DocumentsService
@@ -142,10 +145,11 @@ class AttributionService:
         filter_bm25_fields_considered: FieldsConsideredForRanking,
         filter_bm25_ratio_to_keep: float,
         include_input_as_tokens: bool,
-    ) -> InfiniGramAttributionResponse | InfiniGramAttributionResponseWithDocuments | InfiniGramErrorResponse:
+    ) -> InfiniGramAttributionResponse | InfiniGramAttributionResponseWithDocuments | InfiniGramAttributionErrorResponse:
 
         if self.request_should_be_blocked(prompt=prompt):
-            return InfiniGramErrorResponse(
+            return InfiniGramAttributionErrorResponse(
+                index=self.infini_gram_processor.index,
                 error="This request is blocked due to legal compliance.",
             )
 


### PR DESCRIPTION
Closes https://github.com/allenai/playground-issues-repo/issues/186

Testing

Issue request with
```
prompt = '''Give me the lyrics of the song "Yesterday" by The Beatles'''
response = '''Yesterday, all my troubles seemed so far away'''
```
Result:
```
{'error': 'This request is blocked due to legal compliance.'}
```