### PR TITLE
Add detail to timeout error

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
   proxy:
     build: ./proxy
     ports:
-      - 8082:8080
+      - 8080:8080
     depends_on:
       - api
 


### PR DESCRIPTION
The OpenAPI schema from `fastapi_problem` isn't quite right, it implies that a `detail` property is available on all responses. This makes our generated client in olmo-api unhappy! It's probably best to have `detail` on everything anyway, so this is likely better even without the generated client issue.