### PR TITLE
Rate limit requests to infinigram-api

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -152,7 +152,8 @@ function(
     };
 
     local rateLimitAnnotations = {
-        'nginx.ingress.kubernetes.io/limit-rpm': '1'
+        'nginx.ingress.kubernetes.io/limit-rps': '5',
+        'nginx.ingress.kubernetes.io/limit-burst-multiplier': '1'
     };
 
     local tls = util.getTLSConfig(fullyQualifiedName, hosts);
@@ -160,7 +161,7 @@ function(
         apiVersion: 'networking.k8s.io/v1',
         kind: 'Ingress',
         metadata: {
-            name: fullyQualifiedName + '-ingress',
+            name: fullyQualifiedName,
             namespace: namespaceName,
             labels: labels,
             annotations: annotations + tls.ingressAnnotations + util.getAuthAnnotations(config, '.apps.allenai.org') + rateLimitAnnotations + {


### PR DESCRIPTION
Closes https://github.com/allenai/playground-issues-repo/issues/260

This tells each ingress to allow 5 requests per second per IP through. 

The base limit per second is 5. The burst limit multiplier is set to 1, making the total allowed reqs/s/IP 5.

This isn't intended to stop people from overloading our workers, it just helps us ensure one person doesn't break the application for everyone else.