### PR TITLE
Add indexes for Tulu post-training data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ infinigram-array
 
 api/performance-profiles
 data/
-
+index/

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -333,7 +333,28 @@ function(
                 claimName: "infinigram-v4-olmo-2-0325-32b-anneal-adapt",
                 readOnly: true,
             }
-        }
+        },
+        {
+            name: "infinigram-array-v4-tulu-3-8b-adapt-llama",
+            persistentVolumeClaim: {
+                claimName: "infinigram-v4-tulu-3-8b-adapt-llama",
+                readOnly: true,
+            }
+        },
+        {
+            name: "infinigram-array-v4-tulu-3-70b-adapt-llama",
+            persistentVolumeClaim: {
+                claimName: "infinigram-v4-tulu-3-70b-adapt-llama",
+                readOnly: true,
+            }
+        },
+        {
+            name: "infinigram-array-v4-tulu-3-405b-adapt-llama",
+            persistentVolumeClaim: {
+                claimName: "infinigram-v4-tulu-3-405b-adapt-llama",
+                readOnly: true,
+            }
+        },
     ];
 
     local indexVolumeMounts = [
@@ -366,7 +387,22 @@ function(
             mountPath: "/mnt/infinigram-array/v4-olmo-2-0325-32b-anneal-adapt",
             name: "infinigram-array-v4-olmo-2-0325-32b-anneal-adapt",
             readOnly: true,
-        }
+        },
+        {
+            mountPath: "/mnt/infinigram-array/v4-tulu-3-8b-adapt-llama",
+            name: "infinigram-array-v4-tulu-3-8b-adapt-llama",
+            readOnly: true,
+        },
+        {
+            mountPath: "/mnt/infinigram-array/v4-tulu-3-70b-adapt-llama",
+            name: "infinigram-array-v4-tulu-3-70b-adapt-llama",
+            readOnly: true,
+        },
+        {
+            mountPath: "/mnt/infinigram-array/v4-tulu-3-405b-adapt-llama",
+            name: "infinigram-array-v4-tulu-3-405b-adapt-llama",
+            readOnly: true,
+        },
     ];
 
     local deployment = {

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -335,21 +335,21 @@ function(
             }
         },
         {
-            name: "infinigram-array-v4-tulu-3-8b-adapt-llama",
+            name: "infinigram-array-v4-tulu-3-8b-adapt",
             persistentVolumeClaim: {
                 claimName: "infinigram-v4-tulu-3-8b-adapt-llama",
                 readOnly: true,
             }
         },
         {
-            name: "infinigram-array-v4-tulu-3-70b-adapt-llama",
+            name: "infinigram-array-v4-tulu-3-70b-adapt",
             persistentVolumeClaim: {
                 claimName: "infinigram-v4-tulu-3-70b-adapt-llama",
                 readOnly: true,
             }
         },
         {
-            name: "infinigram-array-v4-tulu-3-405b-adapt-llama",
+            name: "infinigram-array-v4-tulu-3-405b-adapt",
             persistentVolumeClaim: {
                 claimName: "infinigram-v4-tulu-3-405b-adapt-llama",
                 readOnly: true,
@@ -389,18 +389,18 @@ function(
             readOnly: true,
         },
         {
-            mountPath: "/mnt/infinigram-array/v4-tulu-3-8b-adapt-llama",
-            name: "infinigram-array-v4-tulu-3-8b-adapt-llama",
+            mountPath: "/mnt/infinigram-array/v4-tulu-3-8b-adapt",
+            name: "infinigram-array-v4-tulu-3-8b-adapt",
             readOnly: true,
         },
         {
-            mountPath: "/mnt/infinigram-array/v4-tulu-3-70b-adapt-llama",
-            name: "infinigram-array-v4-tulu-3-70b-adapt-llama",
+            mountPath: "/mnt/infinigram-array/v4-tulu-3-70b-adapt",
+            name: "infinigram-array-v4-tulu-3-70b-adapt",
             readOnly: true,
         },
         {
-            mountPath: "/mnt/infinigram-array/v4-tulu-3-405b-adapt-llama",
-            name: "infinigram-array-v4-tulu-3-405b-adapt-llama",
+            mountPath: "/mnt/infinigram-array/v4-tulu-3-405b-adapt",
+            name: "infinigram-array-v4-tulu-3-405b-adapt",
             readOnly: true,
         },
     ];

--- a/bin/download-infini-gram-array.sh
+++ b/bin/download-infini-gram-array.sh
@@ -34,3 +34,20 @@ if [ ! -d $INFINIGRAM_ARRAY_DIR/v4-olmo-2-0325-32b-anneal-adapt ]; then
     echo "creating a link from v4_pileval_llama to v4-olmo-2-0325-32b-anneal-adapt"
     ln -s $INFINIGRAM_ARRAY_DIR/v4_pileval_llama $INFINIGRAM_ARRAY_DIR/v4-olmo-2-0325-32b-anneal-adapt
 fi
+
+if [ ! -d $INFINIGRAM_ARRAY_DIR/v4-tulu-3-8b-adapt-llama ]; then
+    echo "creating a link from v4_pileval_llama to v4-tulu-3-8b-adapt-llama"
+    ln -s $INFINIGRAM_ARRAY_DIR/v4_pileval_llama $INFINIGRAM_ARRAY_DIR/v4-tulu-3-8b-adapt-llama
+fi
+
+if [ ! -d $INFINIGRAM_ARRAY_DIR/v4-tulu-3-70b-adapt-llama ]; then
+    echo "creating a link from v4_pileval_llama to v4-tulu-3-70b-adapt-llama"
+    ln -s $INFINIGRAM_ARRAY_DIR/v4_pileval_llama $INFINIGRAM_ARRAY_DIR/v4-tulu-3-70b-adapt-llama
+fi
+
+if [ ! -d $INFINIGRAM_ARRAY_DIR/v4-tulu-3-405b-adapt-llama ]; then
+    echo "creating a link from v4_pileval_llama to v4-tulu-3-405b-adapt-llama"
+    ln -s $INFINIGRAM_ARRAY_DIR/v4_pileval_llama $INFINIGRAM_ARRAY_DIR/v4-tulu-3-405b-adapt-llama
+fi
+
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,9 @@ services:
       - ./infinigram-array/v4-olmoe-0125-1b-7b-anneal-adapt:/mnt/infinigram-array/v4-olmoe-0125-1b-7b-anneal-adapt
       - ./infinigram-array/v4-olmo-2-1124-13b-anneal-adapt:/mnt/infinigram-array/v4-olmo-2-1124-13b-anneal-adapt
       - ./infinigram-array/v4-olmo-2-0325-32b-anneal-adapt:/mnt/infinigram-array/v4-olmo-2-0325-32b-anneal-adapt
+      - ./infinigram-array/v4-tulu-3-8b-adapt-llama:/mnt/infinigram-array/v4-tulu-3-8b-adapt-llama
+      - ./infinigram-array/v4-tulu-3-70b-adapt-llama:/mnt/infinigram-array/v4-tulu-3-70b-adapt-llama
+      - ./infinigram-array/v4-tulu-3-405b-adapt-llama:/mnt/infinigram-array/v4-tulu-3-405b-adapt-llama
     environment: 
       LOG_LEVEL: DEBUG
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318
@@ -43,6 +46,9 @@ services:
       - ./infinigram-array/v4-olmoe-0125-1b-7b-anneal-adapt:/mnt/infinigram-array/v4-olmoe-0125-1b-7b-anneal-adapt
       - ./infinigram-array/v4-olmo-2-1124-13b-anneal-adapt:/mnt/infinigram-array/v4-olmo-2-1124-13b-anneal-adapt
       - ./infinigram-array/v4-olmo-2-0325-32b-anneal-adapt:/mnt/infinigram-array/v4-olmo-2-0325-32b-anneal-adapt
+      - ./infinigram-array/v4-tulu-3-8b-adapt-llama:/mnt/infinigram-array/v4-tulu-3-8b-adapt-llama
+      - ./infinigram-array/v4-tulu-3-70b-adapt-llama:/mnt/infinigram-array/v4-tulu-3-70b-adapt-llama
+      - ./infinigram-array/v4-tulu-3-405b-adapt-llama:/mnt/infinigram-array/v4-tulu-3-405b-adapt-llama
     environment: *shared-env
 
   proxy:

--- a/indexing/process_tulu3.sh
+++ b/indexing/process_tulu3.sh
@@ -1,0 +1,45 @@
+pip install infini-gram zstandard tqdm transformers sentencepiece awscli
+
+python indexing/transform_hf_to_raw_tulu3.py
+
+cd /weka/oe-training-default/jiachengl/he-infinigram-api/raw
+mkdir tulu-3-8b-adapt
+cd tulu-3-8b-adapt
+ln -s ../tulu-3-sft-mixture/0.jsonl tulu-3-sft-mixture.jsonl
+ln -s ../llama-3.1-tulu-3-8b-preference-mixture/0.jsonl llama-3.1-tulu-3-8b-preference-mixture.jsonl
+ln -s ../RLVR-GSM-MATH-IF-Mixed-Constraints/0.jsonl RLVR-GSM-MATH-IF-Mixed-Constraints.jsonl
+cd ..
+
+mkdir tulu-3-70b-adapt
+cd tulu-3-70b-adapt
+ln -s ../tulu-3-sft-mixture/0.jsonl tulu-3-sft-mixture.jsonl
+ln -s ../llama-3.1-tulu-3-70b-preference-mixture/0.jsonl llama-3.1-tulu-3-70b-preference-mixture.jsonl
+ln -s ../RLVR-GSM-MATH-IF-Mixed-Constraints/0.jsonl RLVR-GSM-MATH-IF-Mixed-Constraints.jsonl
+cd ..
+
+mkdir tulu-3-405b-adapt
+cd tulu-3-405b-adapt
+ln -s ../tulu-3-sft-mixture/0.jsonl tulu-3-sft-mixture.jsonl
+ln -s ../llama-3.1-tulu-3-405b-preference-mixture/0.jsonl llama-3.1-tulu-3-405b-preference-mixture.jsonl
+ln -s ../RLVR-MATH/0.jsonl RLVR-MATH.jsonl
+cd ..
+
+cd /opt/miniconda3/lib/python3.10/site-packages/infini_gram
+
+python indexing.py \
+    --tokenizer llama --cpus 64 --mem 900 --shards 1 --add_metadata --add_unigram --ulimit 524288 \
+    --data_dir /weka/oe-training-default/jiachengl/he-infinigram-api/raw/tulu-3-8b-adapt \
+    --save_dir /weka/oe-training-default/jiachengl/he-infinigram-api/index/v4_tulu-3-8b-adapt_llama
+aws s3 sync /weka/oe-training-default/jiachengl/he-infinigram-api/index/v4_tulu-3-8b-adapt_llama s3://infini-gram/index/v4_tulu-3-8b-adapt_llama
+
+python indexing.py \
+    --tokenizer llama --cpus 64 --mem 900 --shards 1 --add_metadata --add_unigram --ulimit 524288 \
+    --data_dir /weka/oe-training-default/jiachengl/he-infinigram-api/raw/tulu-3-70b-adapt \
+    --save_dir /weka/oe-training-default/jiachengl/he-infinigram-api/index/v4_tulu-3-70b-adapt_llama
+aws s3 sync /weka/oe-training-default/jiachengl/he-infinigram-api/index/v4_tulu-3-70b-adapt_llama s3://infini-gram/index/v4_tulu-3-70b-adapt_llama
+
+python indexing.py \
+    --tokenizer llama --cpus 64 --mem 900 --shards 1 --add_metadata --add_unigram --ulimit 524288 \
+    --data_dir /weka/oe-training-default/jiachengl/he-infinigram-api/raw/tulu-3-405b-adapt \
+    --save_dir /weka/oe-training-default/jiachengl/he-infinigram-api/index/v4_tulu-3-405b-adapt_llama
+aws s3 sync /weka/oe-training-default/jiachengl/he-infinigram-api/index/v4_tulu-3-405b-adapt_llama s3://infini-gram/index/v4_tulu-3-405b-adapt_llama

--- a/indexing/transform_hf_to_raw_tulu3.py
+++ b/indexing/transform_hf_to_raw_tulu3.py
@@ -5,7 +5,7 @@ import os
 output_dir = '/weka/oe-training-default/jiachengl/he-infinigram-api/raw'
 
 # SFT
-ds_names = ['tulu-3-sft-olmo-2-mixture', 'tulu-3-sft-olmo-2-mixture-0225']
+ds_names = ['tulu-3-sft-mixture']
 for ds_name in ds_names:
     ds = datasets.load_dataset(f'allenai/{ds_name}', split='train')
     os.makedirs(f'{output_dir}/{ds_name}', exist_ok=True)
@@ -19,7 +19,7 @@ for ds_name in ds_names:
             f.write(json.dumps({'text': text, 'source': ds_name}) + '\n')
 
 # DPO
-ds_names = ['olmoe-0125-1b-7b-preference-mix', 'olmo-2-1124-13b-preference-mix', 'olmo-2-0325-32b-preference-mix']
+ds_names = ['llama-3.1-tulu-3-8b-preference-mixture', 'llama-3.1-tulu-3-70b-preference-mixture', 'llama-3.1-tulu-3-405b-preference-mixture']
 for ds_name in ds_names:
     ds = datasets.load_dataset(f'allenai/{ds_name}', split='train')
     os.makedirs(f'{output_dir}/{ds_name}', exist_ok=True)
@@ -40,7 +40,7 @@ for ds_name in ds_names:
             f.write(json.dumps({'text': text, 'source': ds_name}) + '\n')
 
 # RLVR
-ds_names = ['RLVR-GSM', 'RLVR-GSM-MATH-IF-Mixed-Constraints']
+ds_names = ['RLVR-MATH']
 for ds_name in ds_names:
     ds = datasets.load_dataset(f'allenai/{ds_name}', split='train')
     os.makedirs(f'{output_dir}/{ds_name}', exist_ok=True)

--- a/packages/infini-gram-processor/src/infini_gram_processor/index_mappings.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/index_mappings.py
@@ -11,6 +11,9 @@ class AvailableInfiniGramIndexId(Enum):
     OLMOE_0125_1B_7B = "olmoe-0125-1b-7b"
     OLMO_2_1124_13B = "olmo-2-1124-13b"
     OLMO_2_0325_32B = "olmo-2-0325-32b"
+    TULU_3_8B = "tulu-3-8b"
+    TULU_3_70B = "tulu-3-70b"
+    TULU_3_405B = "tulu-3-405b"
 
 
 class IndexMapping(TypedDict):
@@ -26,6 +29,9 @@ IndexMappings = TypedDict(
         "olmoe-0125-1b-7b": IndexMapping,
         "olmo-2-1124-13b": IndexMapping,
         "olmo-2-0325-32b": IndexMapping,
+        "tulu-3-8b": IndexMapping,
+        "tulu-3-70b": IndexMapping,
+        "tulu-3-405b": IndexMapping,
     },
 )
 
@@ -59,6 +65,27 @@ index_mappings: IndexMappings = {
             f"{tokenizer_config.index_base_path}/olmoe-mix-0924-dclm",
             f"{tokenizer_config.index_base_path}/olmoe-mix-0924-nodclm",
             f"{tokenizer_config.index_base_path}/v4-olmo-2-0325-32b-anneal-adapt",
+        ],
+        "index_dir_diff": [],
+    },
+    AvailableInfiniGramIndexId.TULU_3_8B.value: {
+        "tokenizer": get_llama_2_tokenizer(),
+        "index_dir": [
+            f"{tokenizer_config.index_base_path}/v4-tulu-3-8b-adapt",
+        ],
+        "index_dir_diff": [],
+    },
+    AvailableInfiniGramIndexId.TULU_3_70B.value: {
+        "tokenizer": get_llama_2_tokenizer(),
+        "index_dir": [
+            f"{tokenizer_config.index_base_path}/v4-tulu-3-70b-adapt",
+        ],
+        "index_dir_diff": [],
+    },
+    AvailableInfiniGramIndexId.TULU_3_405B.value: {
+        "tokenizer": get_llama_2_tokenizer(),
+        "index_dir": [
+            f"{tokenizer_config.index_base_path}/v4-tulu-3-405b-adapt",
         ],
         "index_dir_diff": [],
     },

--- a/volume-claims/v4-tulu-3-405b-adapt-llama.yaml
+++ b/volume-claims/v4-tulu-3-405b-adapt-llama.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: infinigram-v4-tulu-3-405b-adapt-llama
+spec:
+  storageClassName: "infinigram"
+  capacity:
+    storage: 11Gi 
+  accessModes:
+    - ReadOnlyMany
+  claimRef:
+    namespace: infinigram-api
+    name: infinigram-v4-tulu-3-405b-adapt-llama
+  csi:
+    driver: pd.csi.storage.gke.io
+    volumeHandle: projects/ai2-reviz/zones/us-west1-b/disks/infinigram-v4-tulu-3-405b-adapt-llama
+    fsType: ext4
+    readOnly: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: infinigram-api
+  name: infinigram-v4-tulu-3-405b-adapt-llama
+spec:
+  storageClassName: "infinigram"
+  volumeName: infinigram-v4-tulu-3-405b-adapt-llama
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 11Gi

--- a/volume-claims/v4-tulu-3-70b-adapt-llama.yaml
+++ b/volume-claims/v4-tulu-3-70b-adapt-llama.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: infinigram-v4-tulu-3-70b-adapt-llama
+spec:
+  storageClassName: "infinigram"
+  capacity:
+    storage: 11Gi 
+  accessModes:
+    - ReadOnlyMany
+  claimRef:
+    namespace: infinigram-api
+    name: infinigram-v4-tulu-3-70b-adapt-llama
+  csi:
+    driver: pd.csi.storage.gke.io
+    volumeHandle: projects/ai2-reviz/zones/us-west1-b/disks/infinigram-v4-tulu-3-70b-adapt-llama
+    fsType: ext4
+    readOnly: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: infinigram-api
+  name: infinigram-v4-tulu-3-70b-adapt-llama
+spec:
+  storageClassName: "infinigram"
+  volumeName: infinigram-v4-tulu-3-70b-adapt-llama
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 11Gi

--- a/volume-claims/v4-tulu-3-8b-adapt-llama.yaml
+++ b/volume-claims/v4-tulu-3-8b-adapt-llama.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: infinigram-v4-tulu-3-8b-adapt-llama
+spec:
+  storageClassName: "infinigram"
+  capacity:
+    storage: 10Gi 
+  accessModes:
+    - ReadOnlyMany
+  claimRef:
+    namespace: infinigram-api
+    name: infinigram-v4-tulu-3-8b-adapt-llama
+  csi:
+    driver: pd.csi.storage.gke.io
+    volumeHandle: projects/ai2-reviz/zones/us-west1-b/disks/infinigram-v4-tulu-3-8b-adapt-llama
+    fsType: ext4
+    readOnly: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: infinigram-api
+  name: infinigram-v4-tulu-3-8b-adapt-llama
+spec:
+  storageClassName: "infinigram"
+  volumeName: infinigram-v4-tulu-3-8b-adapt-llama
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
https://github.com/allenai/playground-issues-repo/issues/408

@mtblanton can you review this and transfer the indexes from S3 to the corresponding GCP disks (same drill as before)? The S3 paths are:
* s3://infini-gram/index/v4_tulu-3-8b-adapt_llama/
* s3://infini-gram/index/v4_tulu-3-70b-adapt_llama/
* s3://infini-gram/index/v4_tulu-3-405b-adapt_llama/