### PR TITLE
Fix indexing doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This application is only made possible by researchers that worked on the infini-
 To develop in this repo, see the [contributing doc](./docs/CONTRIBUTING.md).
 
 ## Indexes
-You can find the index documentation [here](./docs/indexes).
+You can find the index documentation [here](./docs/indexes.md).
 
 ## Architecture
 


### PR DESCRIPTION
Added the missing file extension in the hyperlink