### PR TITLE
remove indexes other than Olmo 3 32B Instruct and Olmo 2 32B

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -494,137 +494,137 @@ function(
         workerImage
     );
 
-    local olmo3_7b_instruct_worker = curriedCreateWorker(
-        'olmo-3-0625-7b-instruct',
-        [
-            {
-                name: "infinigram-array-dolma2-0625-base-shared",
-                persistentVolumeClaim: {
-                    claimName: "infinigram-dolma2-0625-base-shared",
-                    readOnly: true
-                }
-            },
-            {
-                name: "infinigram-array-dolma2-0625-v01-7b",
-                persistentVolumeClaim: {
-                    claimName: "infinigram-dolma2-0625-v01-7b",
-                    readOnly: true
-                }
-            },
-            {
-                name: "infinigram-array-dolci-instruct-sft-7b",
-                persistentVolumeClaim: {
-                    claimName: "infinigram-dolci-instruct-sft-7b",
-                    readOnly: true
-                }
-            }
-        ],
-        [
-            {
-                mountPath: "/mnt/infinigram-array/dolma2-0625-base-shared",
-                name: "infinigram-array-dolma2-0625-base-shared",
-                readOnly: true,
-            },
-            {
-                mountPath: "/mnt/infinigram-array/dolma2-0625-v01-7b",
-                name: "infinigram-array-dolma2-0625-v01-7b",
-                readOnly: true,
-            },
-            {
-                mountPath: "/mnt/infinigram-array/dolci-instruct-sft-7b",
-                name: "infinigram-array-dolci-instruct-sft-7b",
-                readOnly: true,
-            }
-        ]
-    );
+    // local olmo3_7b_instruct_worker = curriedCreateWorker(
+    //     'olmo-3-0625-7b-instruct',
+    //     [
+    //         {
+    //             name: "infinigram-array-dolma2-0625-base-shared",
+    //             persistentVolumeClaim: {
+    //                 claimName: "infinigram-dolma2-0625-base-shared",
+    //                 readOnly: true
+    //             }
+    //         },
+    //         {
+    //             name: "infinigram-array-dolma2-0625-v01-7b",
+    //             persistentVolumeClaim: {
+    //                 claimName: "infinigram-dolma2-0625-v01-7b",
+    //                 readOnly: true
+    //             }
+    //         },
+    //         {
+    //             name: "infinigram-array-dolci-instruct-sft-7b",
+    //             persistentVolumeClaim: {
+    //                 claimName: "infinigram-dolci-instruct-sft-7b",
+    //                 readOnly: true
+    //             }
+    //         }
+    //     ],
+    //     [
+    //         {
+    //             mountPath: "/mnt/infinigram-array/dolma2-0625-base-shared",
+    //             name: "infinigram-array-dolma2-0625-base-shared",
+    //             readOnly: true,
+    //         },
+    //         {
+    //             mountPath: "/mnt/infinigram-array/dolma2-0625-v01-7b",
+    //             name: "infinigram-array-dolma2-0625-v01-7b",
+    //             readOnly: true,
+    //         },
+    //         {
+    //             mountPath: "/mnt/infinigram-array/dolci-instruct-sft-7b",
+    //             name: "infinigram-array-dolci-instruct-sft-7b",
+    //             readOnly: true,
+    //         }
+    //     ]
+    // );
 
-    local olmo3_7b_think_worker = curriedCreateWorker(
-        'olmo-3-0625-7b-think',
-        [
-            {
-                name: "infinigram-array-dolma2-0625-base-shared",
-                persistentVolumeClaim: {
-                    claimName: "infinigram-dolma2-0625-base-shared",
-                    readOnly: true
-                }
-            },
-            {
-                name: "infinigram-array-dolma2-0625-v01-7b",
-                persistentVolumeClaim: {
-                    claimName: "infinigram-dolma2-0625-v01-7b",
-                    readOnly: true
-                }
-            },
-            {
-                name: "infinigram-array-dolci-think-sft-7b",
-                persistentVolumeClaim: {
-                    claimName: "infinigram-dolci-think-sft-7b",
-                    readOnly: true
-                }
-            }
-        ],
-        [
-            {
-                mountPath: "/mnt/infinigram-array/dolma2-0625-base-shared",
-                name: "infinigram-array-dolma2-0625-base-shared",
-                readOnly: true,
-            },
-            {
-                mountPath: "/mnt/infinigram-array/dolma2-0625-v01-7b",
-                name: "infinigram-array-dolma2-0625-v01-7b",
-                readOnly: true,
-            },
-            {
-                mountPath: "/mnt/infinigram-array/dolci-think-sft-7b",
-                name: "infinigram-array-dolci-think-sft-7b",
-                readOnly: true,
-            }
-        ]
-    );
+    // local olmo3_7b_think_worker = curriedCreateWorker(
+    //     'olmo-3-0625-7b-think',
+    //     [
+    //         {
+    //             name: "infinigram-array-dolma2-0625-base-shared",
+    //             persistentVolumeClaim: {
+    //                 claimName: "infinigram-dolma2-0625-base-shared",
+    //                 readOnly: true
+    //             }
+    //         },
+    //         {
+    //             name: "infinigram-array-dolma2-0625-v01-7b",
+    //             persistentVolumeClaim: {
+    //                 claimName: "infinigram-dolma2-0625-v01-7b",
+    //                 readOnly: true
+    //             }
+    //         },
+    //         {
+    //             name: "infinigram-array-dolci-think-sft-7b",
+    //             persistentVolumeClaim: {
+    //                 claimName: "infinigram-dolci-think-sft-7b",
+    //                 readOnly: true
+    //             }
+    //         }
+    //     ],
+    //     [
+    //         {
+    //             mountPath: "/mnt/infinigram-array/dolma2-0625-base-shared",
+    //             name: "infinigram-array-dolma2-0625-base-shared",
+    //             readOnly: true,
+    //         },
+    //         {
+    //             mountPath: "/mnt/infinigram-array/dolma2-0625-v01-7b",
+    //             name: "infinigram-array-dolma2-0625-v01-7b",
+    //             readOnly: true,
+    //         },
+    //         {
+    //             mountPath: "/mnt/infinigram-array/dolci-think-sft-7b",
+    //             name: "infinigram-array-dolci-think-sft-7b",
+    //             readOnly: true,
+    //         }
+    //     ]
+    // );
 
-    local olmo3_32b_think_worker = curriedCreateWorker(
-        'olmo-3-0625-32b-think',
-        [
-            {
-                name: "infinigram-array-dolma2-0625-base-shared",
-                persistentVolumeClaim: {
-                    claimName: "infinigram-dolma2-0625-base-shared",
-                    readOnly: true
-                }
-            },
-            {
-                name: "infinigram-array-v6-dolma2-0625-v02-32b",
-                persistentVolumeClaim: {
-                    claimName: "infinigram-v6-dolma2-0625-v02-32b",
-                    readOnly: true
-                }
-            },
-            {
-                name: "infinigram-array-dolci-think-sft-32b",
-                persistentVolumeClaim: {
-                    claimName: "infinigram-dolci-think-sft-32b",
-                    readOnly: true
-                }
-            }
-        ],
-        [
-            {
-                mountPath: "/mnt/infinigram-array/dolma2-0625-base-shared",
-                name: "infinigram-array-dolma2-0625-base-shared",
-                readOnly: true,
-            },
-            {
-                mountPath: "/mnt/infinigram-array/v6-dolma2-0625-v02-32b",
-                name: "infinigram-array-v6-dolma2-0625-v02-32b",
-                readOnly: true,
-            },
-            {
-                mountPath: "/mnt/infinigram-array/dolci-think-sft-32b",
-                name: "infinigram-array-dolci-think-sft-32b",
-                readOnly: true,
-            }
-        ]
-    );
+    // local olmo3_32b_think_worker = curriedCreateWorker(
+    //     'olmo-3-0625-32b-think',
+    //     [
+    //         {
+    //             name: "infinigram-array-dolma2-0625-base-shared",
+    //             persistentVolumeClaim: {
+    //                 claimName: "infinigram-dolma2-0625-base-shared",
+    //                 readOnly: true
+    //             }
+    //         },
+    //         {
+    //             name: "infinigram-array-v6-dolma2-0625-v02-32b",
+    //             persistentVolumeClaim: {
+    //                 claimName: "infinigram-v6-dolma2-0625-v02-32b",
+    //                 readOnly: true
+    //             }
+    //         },
+    //         {
+    //             name: "infinigram-array-dolci-think-sft-32b",
+    //             persistentVolumeClaim: {
+    //                 claimName: "infinigram-dolci-think-sft-32b",
+    //                 readOnly: true
+    //             }
+    //         }
+    //     ],
+    //     [
+    //         {
+    //             mountPath: "/mnt/infinigram-array/dolma2-0625-base-shared",
+    //             name: "infinigram-array-dolma2-0625-base-shared",
+    //             readOnly: true,
+    //         },
+    //         {
+    //             mountPath: "/mnt/infinigram-array/v6-dolma2-0625-v02-32b",
+    //             name: "infinigram-array-v6-dolma2-0625-v02-32b",
+    //             readOnly: true,
+    //         },
+    //         {
+    //             mountPath: "/mnt/infinigram-array/dolci-think-sft-32b",
+    //             name: "infinigram-array-dolci-think-sft-32b",
+    //             readOnly: true,
+    //         }
+    //     ]
+    // );
     
     local olmo3_32b_instruct_worker = curriedCreateWorker(
         'olmo-3-0625-32b-instruct',
@@ -711,9 +711,6 @@ function(
         deployment,
         service,
         pdb,
-        olmo3_7b_instruct_worker,
-        olmo3_32b_think_worker,
-        olmo3_7b_think_worker,
         olmo3_32b_instruct_worker,
         olmo2_32b_worker
     ];

--- a/packages/infini-gram-processor/src/infini_gram_processor/index_mappings.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/index_mappings.py
@@ -39,9 +39,9 @@ IndexMappings = TypedDict(
         # "tulu-3-8b": IndexMapping,
         # "tulu-3-70b": IndexMapping,
         # "tulu-3-405b": IndexMapping,
-        "olmo-3-0625-7b-think": IndexMapping,
-        "olmo-3-0625-7b-instruct": IndexMapping,
-        "olmo-3-0625-32b-think": IndexMapping,
+        # "olmo-3-0625-7b-think": IndexMapping,
+        # "olmo-3-0625-7b-instruct": IndexMapping,
+        # "olmo-3-0625-32b-think": IndexMapping,
         "olmo-3-0625-32b-instruct": IndexMapping,
     },
 )
@@ -107,36 +107,36 @@ index_mappings: IndexMappings = {
     #     "index_dir_diff": [],
     #     "token_dtype": "u16",
     # },
-    AvailableInfiniGramIndexId.OLMO_3_0625_7B_THINK.value: {
-        "tokenizer_factory": get_dolma_2_tokenizer,
-        "index_dir": [
-            f"{tokenizer_config.index_base_path}/dolma2-0625-base-shared",
-            f"{tokenizer_config.index_base_path}/dolma2-0625-v01-7b",
-            f"{tokenizer_config.index_base_path}/dolci-think-sft-7b",
-        ],
-        "index_dir_diff": [],
-        "token_dtype": "u32",
-    },
-    AvailableInfiniGramIndexId.OLMO_3_0625_7B_INSTRUCT.value: {
-        "tokenizer_factory": get_dolma_2_tokenizer,
-        "index_dir": [
-            f"{tokenizer_config.index_base_path}/dolma2-0625-base-shared",
-            f"{tokenizer_config.index_base_path}/dolma2-0625-v01-7b",
-            f"{tokenizer_config.index_base_path}/dolci-instruct-sft-7b",
-        ],
-        "index_dir_diff": [],
-        "token_dtype": "u32",
-    },
-    AvailableInfiniGramIndexId.OLMO_3_0625_32B_THINK.value: {
-        "tokenizer_factory": get_dolma_2_tokenizer,
-        "index_dir": [
-            f"{tokenizer_config.index_base_path}/dolma2-0625-base-shared",
-            f"{tokenizer_config.index_base_path}/v6-dolma2-0625-v02-32b",
-            f"{tokenizer_config.index_base_path}/dolci-think-sft-32b",
-        ],
-        "index_dir_diff": [],
-        "token_dtype": "u32",
-    },
+    # AvailableInfiniGramIndexId.OLMO_3_0625_7B_THINK.value: {
+    #     "tokenizer_factory": get_dolma_2_tokenizer,
+    #     "index_dir": [
+    #         f"{tokenizer_config.index_base_path}/dolma2-0625-base-shared",
+    #         f"{tokenizer_config.index_base_path}/dolma2-0625-v01-7b",
+    #         f"{tokenizer_config.index_base_path}/dolci-think-sft-7b",
+    #     ],
+    #     "index_dir_diff": [],
+    #     "token_dtype": "u32",
+    # },
+    # AvailableInfiniGramIndexId.OLMO_3_0625_7B_INSTRUCT.value: {
+    #     "tokenizer_factory": get_dolma_2_tokenizer,
+    #     "index_dir": [
+    #         f"{tokenizer_config.index_base_path}/dolma2-0625-base-shared",
+    #         f"{tokenizer_config.index_base_path}/dolma2-0625-v01-7b",
+    #         f"{tokenizer_config.index_base_path}/dolci-instruct-sft-7b",
+    #     ],
+    #     "index_dir_diff": [],
+    #     "token_dtype": "u32",
+    # },
+    # AvailableInfiniGramIndexId.OLMO_3_0625_32B_THINK.value: {
+    #     "tokenizer_factory": get_dolma_2_tokenizer,
+    #     "index_dir": [
+    #         f"{tokenizer_config.index_base_path}/dolma2-0625-base-shared",
+    #         f"{tokenizer_config.index_base_path}/v6-dolma2-0625-v02-32b",
+    #         f"{tokenizer_config.index_base_path}/dolci-think-sft-32b",
+    #     ],
+    #     "index_dir_diff": [],
+    #     "token_dtype": "u32",
+    # },
     AvailableInfiniGramIndexId.OLMO_3_0625_32B_INSTRUCT.value: {
         "tokenizer_factory": get_dolma_2_tokenizer,
         "index_dir": [

--- a/packages/infini-gram-processor/src/infini_gram_processor/index_mappings.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/index_mappings.py
@@ -14,9 +14,9 @@ class AvailableInfiniGramIndexId(Enum):
     # TULU_3_8B = "tulu-3-8b"
     # TULU_3_70B = "tulu-3-70b"
     # TULU_3_405B = "tulu-3-405b"
-    OLMO_3_0625_7B_THINK = "olmo-3-0625-7b-think"
-    OLMO_3_0625_7B_INSTRUCT = "olmo-3-0625-7b-instruct"
-    OLMO_3_0625_32B_THINK = "olmo-3-0625-32b-think"
+    # OLMO_3_0625_7B_THINK = "olmo-3-0625-7b-think"
+    # OLMO_3_0625_7B_INSTRUCT = "olmo-3-0625-7b-instruct"
+    # OLMO_3_0625_32B_THINK = "olmo-3-0625-32b-think"
     OLMO_3_0625_32B_INSTRUCT = "olmo-3-0625-32b-instruct"
 
 


### PR DESCRIPTION
Closes https://github.com/allenai/playground-issues-repo/issues/999

We've been asked to turn off some of the less popular workers for cost reasons. This PR disables all indexes other than the ones for Olmo 3 32B Instruct and Olmo 2 32B.

If we'd like to bring some of these indexes back in the future we should look into combining the indexes into one worker again!