### PR TITLE
Add count functionality to this API

### DIFF
--- a/api/src/attribution/attribution_queue_service.py
+++ b/api/src/attribution/attribution_queue_service.py
@@ -4,26 +4,18 @@ from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
 from infinigram_api_shared.saq.queue_constants import TASK_NAME_KEY, TASK_TAG_KEY
 from infinigram_api_shared.saq.queue_utils import (
     get_attribute_job_name_for_index,
-    get_queue_for_index,
 )
 from opentelemetry import trace
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_SYSTEM,
+)
 from opentelemetry.trace import SpanKind
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-from saq import Queue
 
+from api.src.queue_service import get_queue
 from src.attribution.attribution_request import AttributionRequest
 from src.config import get_config
-
-
-def get_queue(index_id: AvailableInfiniGramIndexId) -> Queue:
-    config = get_config()
-    return get_queue_for_index(
-        queue_url=config.attribution_queue_url,
-        base_queue_name=config.attribution_queue_name,
-        index_id=index_id,
-    )
-
 
 tracer = trace.get_tracer(get_config().application_name)
 
@@ -36,9 +28,9 @@ async def publish_attribution_job(
         kind=SpanKind.PRODUCER,
         attributes={
             TASK_NAME_KEY: "attribute",
-            SpanAttributes.MESSAGING_MESSAGE_ID: job_key,
+            MESSAGING_MESSAGE_ID: job_key,
             TASK_TAG_KEY: "apply_async",
-            SpanAttributes.MESSAGING_SYSTEM: "saq",
+            MESSAGING_SYSTEM: "saq",
             "index": index.value,
         },
     ):
@@ -63,12 +55,3 @@ async def publish_attribution_job(
             maximum_documents_per_span=request.maximum_documents_per_span,
             otel_context=otel_context,
         )
-
-
-async def abort_attribution_job(
-    job_key: str, index: AvailableInfiniGramIndexId
-) -> None:
-    job_to_abort = await get_queue(index).job(job_key)
-
-    if job_to_abort is not None:
-        await get_queue(index).abort(job_to_abort, "Client timeout")

--- a/api/src/attribution/attribution_queue_service.py
+++ b/api/src/attribution/attribution_queue_service.py
@@ -13,9 +13,9 @@ from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
 from opentelemetry.trace import SpanKind
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
-from api.src.queue_service import get_queue
 from src.attribution.attribution_request import AttributionRequest
 from src.config import get_config
+from src.queue_service import get_queue
 
 tracer = trace.get_tracer(get_config().application_name)
 

--- a/api/src/attribution/attribution_service.py
+++ b/api/src/attribution/attribution_service.py
@@ -14,8 +14,8 @@ from pydantic import Field, ValidationError
 from redis.asyncio import Redis
 from rfc9457 import StatusProblem
 
+from api.src.queue_service import abort_job
 from src.attribution.attribution_queue_service import (
-    abort_attribution_job,
     publish_attribution_job,
 )
 from src.attribution.attribution_request import AttributionRequest
@@ -180,7 +180,7 @@ class AttributionService:
                 ex, attributes={"job_key": job_key, "index": index.value}
             )
 
-            await abort_attribution_job(job_key, index=index)
+            await abort_job(job_key, index=index)
 
             raise AttributionTimeoutError(
                 "The server wasn't able to process your request in time. It is likely overloaded. Please try again later."

--- a/api/src/attribution/attribution_service.py
+++ b/api/src/attribution/attribution_service.py
@@ -14,7 +14,6 @@ from pydantic import Field, ValidationError
 from redis.asyncio import Redis
 from rfc9457 import StatusProblem
 
-from api.src.queue_service import abort_job
 from src.attribution.attribution_queue_service import (
     publish_attribution_job,
 )
@@ -22,6 +21,7 @@ from src.attribution.attribution_request import AttributionRequest
 from src.cache import CacheDependency
 from src.camel_case_model import CamelCaseModel
 from src.config import get_config
+from src.queue_service import abort_job
 
 tracer = trace.get_tracer(get_config().application_name)
 logger = logging.getLogger("uvicorn.error")

--- a/api/src/infinigram/count_service.py
+++ b/api/src/infinigram/count_service.py
@@ -63,7 +63,7 @@ class CountService:
     async def count_cnf(
         self, index: AvailableInfiniGramIndexId, request: CountCnfRequest
     ) -> CountCnfResponse:
-        job_key = f"count_${index}${str(request.__hash__())}"
+        job_key = f"count_${index}_${str(request.__hash__())}"
 
         try:
             logger.debug("Adding count request to queue", extra={"index": index})

--- a/api/src/infinigram/count_service.py
+++ b/api/src/infinigram/count_service.py
@@ -1,51 +1,22 @@
 import logging
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import Depends
 from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
-from infini_gram_processor.models.models import CountRequest
-from infinigram_api_shared.saq.queue_constants import TASK_NAME_KEY, TASK_TAG_KEY
-from opentelemetry import trace
-from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
-    MESSAGING_MESSAGE_ID,
-    MESSAGING_SYSTEM,
+from infini_gram_processor.models.models import (
+    CountCnfRequest,
+    CountCnfResponse,
+    CountRequest,
 )
+from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from api.src.attribution.attribution_service import AttributionTimeoutError
 from api.src.camel_case_model import CamelCaseModel
-from api.src.queue_service import abort_job, get_queue
+from api.src.queue_service import abort_job, publish_job
 
 tracer = trace.get_tracer(__name__)
 logger = logging.getLogger("uvicorn.error")
-
-
-async def publish_count_job(
-    index: AvailableInfiniGramIndexId, request: CountRequest, job_key: str
-):
-    with tracer.start_as_current_span(
-        name="count_service/publish_count_job",
-        kind=trace.SpanKind.PRODUCER,
-        attributes={
-            TASK_NAME_KEY: "count",
-            MESSAGING_MESSAGE_ID: job_key,
-            TASK_TAG_KEY: "apply_async",
-            MESSAGING_SYSTEM: "saq",
-            "index": index.value,
-        },
-    ):
-        otel_context: dict[str, Any] = {}
-        TraceContextTextMapPropagator().inject(otel_context)
-
-        return await get_queue(index).apply(
-            "count",
-            timeout=15,
-            key=job_key,
-            index=index.value,
-            query=request.query,
-            otel_context=otel_context,
-        )
 
 
 class CountResponse(CamelCaseModel):
@@ -55,19 +26,61 @@ class CountResponse(CamelCaseModel):
 
 class CountService:
     @tracer.start_as_current_span("count_service/count")
-    async def count(self, index: AvailableInfiniGramIndexId, request: CountRequest):
+    async def count(
+        self, index: AvailableInfiniGramIndexId, request: CountRequest
+    ) -> CountResponse:
         job_key = f"count_${str(request.__hash__())}"
 
         try:
             logger.debug("Adding count request to queue", extra={"index": index})
 
-            count_result_json = await publish_count_job(index, request, job_key)
+            count_result_json = await publish_job(
+                index, job_key=job_key, task_name="count", query=request.query
+            )
             count_result = CountResponse.model_validate_json(count_result_json)
 
             return count_result
         except TimeoutError as ex:
             logger.error(
-                "Attribution request timed out",
+                "Count request timed out",
+                extra={"job_key": job_key, "index": index},
+            )
+
+            current_span = trace.get_current_span()
+            current_span.set_status(Status(StatusCode.ERROR))
+            current_span.record_exception(
+                ex, attributes={"job_key": job_key, "index": index.value}
+            )
+
+            await abort_job(job_key, index=index)
+
+            raise AttributionTimeoutError(
+                "The server wasn't able to process your request in time. It is likely overloaded. Please try again later."
+            )
+
+    @tracer.start_as_current_span("count_service/count_cnf")
+    async def count_cnf(
+        self, index: AvailableInfiniGramIndexId, request: CountCnfRequest
+    ) -> CountCnfResponse:
+        job_key = f"count_${str(request.__hash__())}"
+
+        try:
+            logger.debug("Adding count request to queue", extra={"index": index})
+
+            count_result_json = await publish_job(
+                index=index,
+                job_key=job_key,
+                task_name="count_cnf",
+                query=request.query,
+                max_clause_freq=request.max_clause_freq,
+                max_diff_tokens=request.max_diff_tokens,
+            )
+            count_result = CountCnfResponse.model_validate_json(count_result_json)
+
+            return count_result
+        except TimeoutError as ex:
+            logger.error(
+                "Count CNF request timed out",
                 extra={"job_key": job_key, "index": index},
             )
 

--- a/api/src/infinigram/count_service.py
+++ b/api/src/infinigram/count_service.py
@@ -8,6 +8,7 @@ from infini_gram_processor.models.models import (
     CountCnfResponse,
     CountRequest,
 )
+from infinigram_api_shared.saq.queue_utils import Jobs
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
@@ -35,7 +36,7 @@ class CountService:
             logger.debug("Adding count request to queue", extra={"index": index})
 
             count_result_json = await publish_job(
-                index, job_key=job_key, task_name="count", query=request.query
+                index, job_key=job_key, job_name=Jobs.COUNT, query=request.query
             )
             count_result = CountResponse.model_validate_json(count_result_json)
 
@@ -70,7 +71,7 @@ class CountService:
             count_result_json = await publish_job(
                 index=index,
                 job_key=job_key,
-                task_name="count_cnf",
+                job_name=Jobs.COUNT_CNF,
                 query=request.query,
                 max_clause_freq=request.max_clause_freq,
                 max_diff_tokens=request.max_diff_tokens,

--- a/api/src/infinigram/count_service.py
+++ b/api/src/infinigram/count_service.py
@@ -12,9 +12,9 @@ from infinigram_api_shared.saq.queue_utils import Jobs
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
-from api.src.attribution.attribution_service import AttributionTimeoutError
-from api.src.camel_case_model import CamelCaseModel
-from api.src.queue_service import abort_job, publish_job
+from src.attribution.attribution_service import AttributionTimeoutError
+from src.camel_case_model import CamelCaseModel
+from src.queue_service import abort_job, publish_job
 
 tracer = trace.get_tracer(__name__)
 logger = logging.getLogger("uvicorn.error")

--- a/api/src/infinigram/count_service.py
+++ b/api/src/infinigram/count_service.py
@@ -30,7 +30,7 @@ class CountService:
     async def count(
         self, index: AvailableInfiniGramIndexId, request: CountRequest
     ) -> CountResponse:
-        job_key = f"count_${index}_${str(request.__hash__())}"
+        job_key = f"count_{index.value}_{str(request.__hash__())}"
 
         try:
             logger.debug("Adding count request to queue", extra={"index": index})
@@ -63,7 +63,7 @@ class CountService:
     async def count_cnf(
         self, index: AvailableInfiniGramIndexId, request: CountCnfRequest
     ) -> CountCnfResponse:
-        job_key = f"count_${index}_${str(request.__hash__())}"
+        job_key = f"count_{index}_{str(request.__hash__())}"
 
         try:
             logger.debug("Adding count request to queue", extra={"index": index})

--- a/api/src/infinigram/count_service.py
+++ b/api/src/infinigram/count_service.py
@@ -1,0 +1,87 @@
+import logging
+from typing import Annotated, Any
+
+from fastapi import Depends
+from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
+from infini_gram_processor.models.models import CountRequest
+from infinigram_api_shared.saq.queue_constants import TASK_NAME_KEY, TASK_TAG_KEY
+from opentelemetry import trace
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_SYSTEM,
+)
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+from api.src.attribution.attribution_service import AttributionTimeoutError
+from api.src.camel_case_model import CamelCaseModel
+from api.src.queue_service import abort_job, get_queue
+
+tracer = trace.get_tracer(__name__)
+logger = logging.getLogger("uvicorn.error")
+
+
+async def publish_count_job(
+    index: AvailableInfiniGramIndexId, request: CountRequest, job_key: str
+):
+    with tracer.start_as_current_span(
+        name="count_service/publish_count_job",
+        kind=trace.SpanKind.PRODUCER,
+        attributes={
+            TASK_NAME_KEY: "count",
+            MESSAGING_MESSAGE_ID: job_key,
+            TASK_TAG_KEY: "apply_async",
+            MESSAGING_SYSTEM: "saq",
+            "index": index.value,
+        },
+    ):
+        otel_context: dict[str, Any] = {}
+        TraceContextTextMapPropagator().inject(otel_context)
+
+        return await get_queue(index).apply(
+            "count",
+            timeout=15,
+            key=job_key,
+            index=index.value,
+            query=request.query,
+            otel_context=otel_context,
+        )
+
+
+class CountResponse(CamelCaseModel):
+    approx: bool
+    count: int
+
+
+class CountService:
+    @tracer.start_as_current_span("count_service/count")
+    async def count(self, index: AvailableInfiniGramIndexId, request: CountRequest):
+        job_key = f"count_${str(request.__hash__())}"
+
+        try:
+            logger.debug("Adding count request to queue", extra={"index": index})
+
+            count_result_json = await publish_count_job(index, request, job_key)
+            count_result = CountResponse.model_validate_json(count_result_json)
+
+            return count_result
+        except TimeoutError as ex:
+            logger.error(
+                "Attribution request timed out",
+                extra={"job_key": job_key, "index": index},
+            )
+
+            current_span = trace.get_current_span()
+            current_span.set_status(Status(StatusCode.ERROR))
+            current_span.record_exception(
+                ex, attributes={"job_key": job_key, "index": index.value}
+            )
+
+            await abort_job(job_key, index=index)
+
+            raise AttributionTimeoutError(
+                "The server wasn't able to process your request in time. It is likely overloaded. Please try again later."
+            )
+
+
+CountServiceDependency = Annotated[CountService, Depends()]

--- a/api/src/infinigram/count_service.py
+++ b/api/src/infinigram/count_service.py
@@ -30,7 +30,7 @@ class CountService:
     async def count(
         self, index: AvailableInfiniGramIndexId, request: CountRequest
     ) -> CountResponse:
-        job_key = f"count_${str(request.__hash__())}"
+        job_key = f"count_${index}_${str(request.__hash__())}"
 
         try:
             logger.debug("Adding count request to queue", extra={"index": index})
@@ -63,7 +63,7 @@ class CountService:
     async def count_cnf(
         self, index: AvailableInfiniGramIndexId, request: CountCnfRequest
     ) -> CountCnfResponse:
-        job_key = f"count_${str(request.__hash__())}"
+        job_key = f"count_${index}${str(request.__hash__())}"
 
         try:
             logger.debug("Adding count request to queue", extra={"index": index})

--- a/api/src/infinigram/infinigram_router.py
+++ b/api/src/infinigram/infinigram_router.py
@@ -1,5 +1,8 @@
 from fastapi import APIRouter
 from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
+from infini_gram_processor.models.models import CountCnfRequest, CountRequest
+
+from api.src.infinigram.count_service import CountServiceDependency
 
 infinigram_router = APIRouter()
 
@@ -7,3 +10,20 @@ infinigram_router = APIRouter()
 @infinigram_router.get(path="/indexes")
 def get_available_indexes() -> list[AvailableInfiniGramIndexId]:
     return [index for index in AvailableInfiniGramIndexId]
+
+
+@infinigram_router.post("/{index}/count")
+async def count(
+    index: AvailableInfiniGramIndexId,
+    body: CountRequest,
+    count_service: CountServiceDependency,
+):
+    return await count_service.count(index, body)
+
+
+@infinigram_router.post("/{index}/count_cnf")
+def count_cnf(
+    index: AvailableInfiniGramIndexId,
+    body: CountCnfRequest,
+    count_service: CountServiceDependency,
+): ...

--- a/api/src/infinigram/infinigram_router.py
+++ b/api/src/infinigram/infinigram_router.py
@@ -22,8 +22,9 @@ async def count(
 
 
 @infinigram_router.post("/{index}/count_cnf")
-def count_cnf(
+async def count_cnf(
     index: AvailableInfiniGramIndexId,
     body: CountCnfRequest,
     count_service: CountServiceDependency,
-): ...
+):
+    return await count_service.count_cnf(index, body)

--- a/api/src/infinigram/infinigram_router.py
+++ b/api/src/infinigram/infinigram_router.py
@@ -22,6 +22,12 @@ async def count(
     body: CountRequest,
     count_service: CountServiceDependency,
 ) -> CountResponse:
+    """
+    This query type counts the number of times the query string appears in the corpus. If the query is an empty string, the total number of tokens in the corpus will be returned.
+
+    For more info, see the infini-gram package docs: https://infini-gram.readthedocs.io/en/latest/pkg.html#count-an-n-gram-or-a-cnf-of-multiple-n-grams
+    """
+
     return await count_service.count(index, body)
 
 
@@ -31,4 +37,12 @@ async def count_cnf(
     body: CountCnfRequest,
     count_service: CountServiceDependency,
 ) -> CountCnfResponse:
+    """
+    This query type counts the number of times the query string appears in the corpus. If the query is an empty string, the total number of tokens in the corpus will be returned.
+
+    You can simply enter a string, in which we count the number of occurrences of the string. You can also connect multiple strings with the AND/OR operators, in the CNF format, in which case we count the number of times where this logical constraint is satisfied.
+
+    For more info, see the infini-gram package docs: https://infini-gram.readthedocs.io/en/latest/pkg.html#count-an-n-gram-or-a-cnf-of-multiple-n-grams
+    """
+
     return await count_service.count_cnf(index, body)

--- a/api/src/infinigram/infinigram_router.py
+++ b/api/src/infinigram/infinigram_router.py
@@ -1,8 +1,12 @@
 from fastapi import APIRouter
 from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
-from infini_gram_processor.models.models import CountCnfRequest, CountRequest
+from infini_gram_processor.models.models import (
+    CountCnfRequest,
+    CountCnfResponse,
+    CountRequest,
+)
 
-from api.src.infinigram.count_service import CountServiceDependency
+from src.infinigram.count_service import CountResponse, CountServiceDependency
 
 infinigram_router = APIRouter()
 
@@ -17,7 +21,7 @@ async def count(
     index: AvailableInfiniGramIndexId,
     body: CountRequest,
     count_service: CountServiceDependency,
-):
+) -> CountResponse:
     return await count_service.count(index, body)
 
 
@@ -26,5 +30,5 @@ async def count_cnf(
     index: AvailableInfiniGramIndexId,
     body: CountCnfRequest,
     count_service: CountServiceDependency,
-):
+) -> CountCnfResponse:
     return await count_service.count_cnf(index, body)

--- a/api/src/queue_service.py
+++ b/api/src/queue_service.py
@@ -1,0 +1,21 @@
+from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
+from infinigram_api_shared.saq.queue_utils import get_queue_for_index
+from saq import Queue
+
+from api.src.config import get_config
+
+
+def get_queue(index_id: AvailableInfiniGramIndexId) -> Queue:
+    config = get_config()
+    return get_queue_for_index(
+        queue_url=config.attribution_queue_url,
+        base_queue_name=config.attribution_queue_name,
+        index_id=index_id,
+    )
+
+
+async def abort_job(job_key: str, index: AvailableInfiniGramIndexId) -> None:
+    job_to_abort = await get_queue(index).job(job_key)
+
+    if job_to_abort is not None:
+        await get_queue(index).abort(job_to_abort, "Client timeout")

--- a/api/src/queue_service.py
+++ b/api/src/queue_service.py
@@ -1,8 +1,19 @@
+from typing import Any
+
 from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
+from infinigram_api_shared.saq.queue_constants import TASK_NAME_KEY, TASK_TAG_KEY
 from infinigram_api_shared.saq.queue_utils import get_queue_for_index
+from opentelemetry import trace
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_SYSTEM,
+)
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from saq import Queue
 
 from api.src.config import get_config
+
+tracer = trace.get_tracer(__name__)
 
 
 def get_queue(index_id: AvailableInfiniGramIndexId) -> Queue:
@@ -19,3 +30,30 @@ async def abort_job(job_key: str, index: AvailableInfiniGramIndexId) -> None:
 
     if job_to_abort is not None:
         await get_queue(index).abort(job_to_abort, "Client timeout")
+
+
+async def publish_job(
+    index: AvailableInfiniGramIndexId, job_key: str, task_name: str, **kwargs
+):
+    with tracer.start_as_current_span(
+        name="count_service/publish_count_job",
+        kind=trace.SpanKind.PRODUCER,
+        attributes={
+            TASK_NAME_KEY: task_name,
+            MESSAGING_MESSAGE_ID: job_key,
+            TASK_TAG_KEY: "apply_async",
+            MESSAGING_SYSTEM: "saq",
+            "index": index.value,
+        },
+    ):
+        otel_context: dict[str, Any] = {}
+        TraceContextTextMapPropagator().inject(otel_context)
+
+        return await get_queue(index).apply(
+            task_name,
+            timeout=15,
+            key=job_key,
+            index=index.value,
+            otel_context=otel_context,
+            **kwargs,
+        )

--- a/api/src/queue_service.py
+++ b/api/src/queue_service.py
@@ -11,7 +11,7 @@ from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from saq import Queue
 
-from api.src.config import get_config
+from src.config import get_config
 
 tracer = trace.get_tracer(__name__)
 
@@ -33,8 +33,11 @@ async def abort_job(job_key: str, index: AvailableInfiniGramIndexId) -> None:
 
 
 async def publish_job(
-    index: AvailableInfiniGramIndexId, job_key: str, job_name: Jobs, **kwargs
-):
+    index: AvailableInfiniGramIndexId,
+    job_key: str,
+    job_name: Jobs,
+    **kwargs: Any,
+) -> Any:
     with tracer.start_as_current_span(
         name="count_service/publish_count_job",
         kind=trace.SpanKind.PRODUCER,

--- a/api/src/queue_service.py
+++ b/api/src/queue_service.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
 from infinigram_api_shared.saq.queue_constants import TASK_NAME_KEY, TASK_TAG_KEY
-from infinigram_api_shared.saq.queue_utils import get_queue_for_index
+from infinigram_api_shared.saq.queue_utils import Jobs, get_queue_for_index
 from opentelemetry import trace
 from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
     MESSAGING_MESSAGE_ID,
@@ -33,13 +33,13 @@ async def abort_job(job_key: str, index: AvailableInfiniGramIndexId) -> None:
 
 
 async def publish_job(
-    index: AvailableInfiniGramIndexId, job_key: str, task_name: str, **kwargs
+    index: AvailableInfiniGramIndexId, job_key: str, job_name: Jobs, **kwargs
 ):
     with tracer.start_as_current_span(
         name="count_service/publish_count_job",
         kind=trace.SpanKind.PRODUCER,
         attributes={
-            TASK_NAME_KEY: task_name,
+            TASK_NAME_KEY: job_name,
             MESSAGING_MESSAGE_ID: job_key,
             TASK_TAG_KEY: "apply_async",
             MESSAGING_SYSTEM: "saq",
@@ -50,7 +50,7 @@ async def publish_job(
         TraceContextTextMapPropagator().inject(otel_context)
 
         return await get_queue(index).apply(
-            task_name,
+            job_name,
             timeout=15,
             key=job_key,
             index=index.value,

--- a/attribution_worker/attribution_handler.py
+++ b/attribution_worker/attribution_handler.py
@@ -11,7 +11,11 @@ from infini_gram_processor.models.models import (
 )
 from infinigram_api_shared.saq.queue_constants import TASK_NAME_KEY, TASK_TAG_KEY
 from opentelemetry import trace
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_CLIENT_ID,
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_SYSTEM,
+)
 from opentelemetry.trace import SpanKind
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
@@ -54,18 +58,18 @@ async def attribution_job(
         kind=SpanKind.CLIENT,
         context=extracted_context,
         attributes={
-            SpanAttributes.MESSAGING_SYSTEM: "saq",
+            MESSAGING_SYSTEM: "saq",
             TASK_NAME_KEY: "attribute",
             TASK_TAG_KEY: "apply_async",
         },
     ) as otel_span:
         job = ctx.get("job")
         if job is not None:
-            otel_span.set_attribute(SpanAttributes.MESSAGING_MESSAGE_ID, job.key)
+            otel_span.set_attribute(MESSAGING_MESSAGE_ID, job.key)
 
         worker = ctx.get("worker")
         if worker is not None:
-            otel_span.set_attribute(SpanAttributes.MESSAGING_CLIENT_ID, worker.id)
+            otel_span.set_attribute(MESSAGING_CLIENT_ID, worker.id)
 
         infini_gram_index = ctx["infini_gram_processor"]
 

--- a/attribution_worker/count_handler.py
+++ b/attribution_worker/count_handler.py
@@ -47,8 +47,46 @@ async def count_job(
 
         infini_gram_index = ctx["infini_gram_processor"]
 
+        count_result = await asyncio.to_thread(infini_gram_index.count, query=query)
+
+        return count_result.model_dump_json()
+
+
+async def count_cnf_job(
+    ctx: AttributionWorkerContext,
+    *,
+    query: str | list[list[list[int]]],
+    max_clause_freq: int | None = None,
+    max_diff_tokens: int | None = None,
+    otel_context: dict[str, Any],
+):
+    extracted_context = TraceContextTextMapPropagator().extract(otel_context)
+
+    with tracer.start_as_current_span(
+        name="attribution-worker/count",
+        kind=SpanKind.CLIENT,
+        context=extracted_context,
+        attributes={
+            MESSAGING_SYSTEM: "saq",
+            TASK_NAME_KEY: "attribute",
+            TASK_TAG_KEY: "apply_async",
+        },
+    ) as otel_span:
+        job = ctx.get("job")
+        if job is not None:
+            otel_span.set_attribute(MESSAGING_MESSAGE_ID, job.key)
+
+        worker = ctx.get("worker")
+        if worker is not None:
+            otel_span.set_attribute(MESSAGING_CLIENT_ID, worker.id)
+
+        infini_gram_index = ctx["infini_gram_processor"]
+
         count_result = await asyncio.to_thread(
-            infini_gram_index.count_n_gram, query=query
+            infini_gram_index.count_cnf,
+            query=query,
+            max_clause_freq=max_clause_freq,
+            max_diff_tokens=max_diff_tokens,
         )
 
         return count_result.model_dump_json()

--- a/attribution_worker/count_handler.py
+++ b/attribution_worker/count_handler.py
@@ -59,7 +59,7 @@ async def count_cnf_job(
     max_clause_freq: int | None = None,
     max_diff_tokens: int | None = None,
     otel_context: dict[str, Any],
-):
+) -> str:
     extracted_context = TraceContextTextMapPropagator().extract(otel_context)
 
     with tracer.start_as_current_span(

--- a/attribution_worker/count_handler.py
+++ b/attribution_worker/count_handler.py
@@ -22,6 +22,7 @@ tracer = trace.get_tracer(config.application_name)
 async def count_job(
     ctx: AttributionWorkerContext,
     *,
+    index: str,
     query: str,
     otel_context: dict[str, Any],
 ) -> str:
@@ -55,6 +56,7 @@ async def count_job(
 async def count_cnf_job(
     ctx: AttributionWorkerContext,
     *,
+    index: str,
     query: str | list[list[list[int]]],
     max_clause_freq: int | None = None,
     max_diff_tokens: int | None = None,

--- a/attribution_worker/count_handler.py
+++ b/attribution_worker/count_handler.py
@@ -1,0 +1,54 @@
+import asyncio
+from typing import Any
+
+from infinigram_api_shared.saq.queue_constants import TASK_NAME_KEY, TASK_TAG_KEY
+from opentelemetry import trace
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_CLIENT_ID,
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_SYSTEM,
+)
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+from attribution_worker.attribution_worker_context import AttributionWorkerContext
+from attribution_worker.config import get_config
+
+config = get_config()
+
+tracer = trace.get_tracer(config.application_name)
+
+
+async def count_job(
+    ctx: AttributionWorkerContext,
+    *,
+    query: str,
+    otel_context: dict[str, Any],
+) -> str:
+    extracted_context = TraceContextTextMapPropagator().extract(otel_context)
+
+    with tracer.start_as_current_span(
+        name="attribution-worker/count",
+        kind=SpanKind.CLIENT,
+        context=extracted_context,
+        attributes={
+            MESSAGING_SYSTEM: "saq",
+            TASK_NAME_KEY: "attribute",
+            TASK_TAG_KEY: "apply_async",
+        },
+    ) as otel_span:
+        job = ctx.get("job")
+        if job is not None:
+            otel_span.set_attribute(MESSAGING_MESSAGE_ID, job.key)
+
+        worker = ctx.get("worker")
+        if worker is not None:
+            otel_span.set_attribute(MESSAGING_CLIENT_ID, worker.id)
+
+        infini_gram_index = ctx["infini_gram_processor"]
+
+        count_result = await asyncio.to_thread(
+            infini_gram_index.count_n_gram, query=query
+        )
+
+        return count_result.model_dump_json()

--- a/attribution_worker/worker.py
+++ b/attribution_worker/worker.py
@@ -4,6 +4,7 @@ import os
 from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
 from infini_gram_processor.processor import InfiniGramProcessor
 from infinigram_api_shared.saq.queue_utils import (
+    Jobs,
     get_attribute_job_name_for_index,
     get_queue_name,
 )
@@ -11,6 +12,7 @@ from saq import Queue
 from saq.types import SettingsDict
 
 from attribution_worker.attribution_worker_context import AttributionWorkerContext
+from attribution_worker.count_handler import count_cnf_job, count_job
 
 from .attribution_handler import attribution_job
 from .config import get_config
@@ -53,7 +55,9 @@ async def startup(ctx: AttributionWorkerContext) -> None:
 settings = SettingsDict(
     queue=queue,
     functions=[
-        (get_attribute_job_name_for_index(assigned_index_enum), attribution_job)  # type: ignore[list-item] # The type for this isn't general enough to work with our fns
+        (get_attribute_job_name_for_index(assigned_index_enum), attribution_job),
+        (Jobs.COUNT, count_job),
+        (Jobs.COUNT_CNF, count_cnf_job),
     ],
     startup=startup,
     concurrency=1,

--- a/attribution_worker/worker.py
+++ b/attribution_worker/worker.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import cast
 
 from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
 from infini_gram_processor.processor import InfiniGramProcessor
@@ -9,7 +10,7 @@ from infinigram_api_shared.saq.queue_utils import (
     get_queue_name,
 )
 from saq import Queue
-from saq.types import SettingsDict
+from saq.types import Function, SettingsDict
 
 from attribution_worker.attribution_worker_context import AttributionWorkerContext
 from attribution_worker.count_handler import count_cnf_job, count_job
@@ -55,9 +56,12 @@ async def startup(ctx: AttributionWorkerContext) -> None:
 settings = SettingsDict(
     queue=queue,
     functions=[
-        (get_attribute_job_name_for_index(assigned_index_enum), attribution_job),
-        (Jobs.COUNT, count_job),
-        (Jobs.COUNT_CNF, count_cnf_job),
+        (
+            get_attribute_job_name_for_index(assigned_index_enum),
+            cast(Function[AttributionWorkerContext], attribution_job),
+        ),
+        (Jobs.COUNT, cast(Function[AttributionWorkerContext], count_job)),
+        (Jobs.COUNT_CNF, cast(Function[AttributionWorkerContext], count_cnf_job)),
     ],
     startup=startup,
     concurrency=1,

--- a/packages/infini-gram-processor/src/infini_gram_processor/index_mappings.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/index_mappings.py
@@ -3,21 +3,21 @@ from typing import Callable, Iterable, Literal, TypedDict
 
 from .processor_config import tokenizer_config
 from .tokenizers.tokenizer import Tokenizer
-from .tokenizers.tokenizer_factory import get_dolma_2_tokenizer, get_llama_2_tokenizer
+from .tokenizers.tokenizer_factory import get_llama_2_tokenizer
 
 
 class AvailableInfiniGramIndexId(Enum):
-    # PILEVAL_LLAMA = "pileval-llama"
+    PILEVAL_LLAMA = "pileval-llama"
     # OLMOE_0125_1B_7B = "olmoe-0125-1b-7b"
     # OLMO_2_1124_13B = "olmo-2-1124-13b"
-    OLMO_2_0325_32B = "olmo-2-0325-32b"
+    # OLMO_2_0325_32B = "olmo-2-0325-32b"
     # TULU_3_8B = "tulu-3-8b"
     # TULU_3_70B = "tulu-3-70b"
     # TULU_3_405B = "tulu-3-405b"
     # OLMO_3_0625_7B_THINK = "olmo-3-0625-7b-think"
     # OLMO_3_0625_7B_INSTRUCT = "olmo-3-0625-7b-instruct"
     # OLMO_3_0625_32B_THINK = "olmo-3-0625-32b-think"
-    OLMO_3_0625_32B_INSTRUCT = "olmo-3-0625-32b-instruct"
+    # OLMO_3_0625_32B_INSTRUCT = "olmo-3-0625-32b-instruct"
 
 
 class IndexMapping(TypedDict):
@@ -32,27 +32,27 @@ class IndexMapping(TypedDict):
 IndexMappings = TypedDict(
     "IndexMappings",
     {
-        # "pileval-llama": IndexMapping,
+        "pileval-llama": IndexMapping,
         # "olmoe-0125-1b-7b": IndexMapping,
         # "olmo-2-1124-13b": IndexMapping,
-        "olmo-2-0325-32b": IndexMapping,
+        # "olmo-2-0325-32b": IndexMapping,
         # "tulu-3-8b": IndexMapping,
         # "tulu-3-70b": IndexMapping,
         # "tulu-3-405b": IndexMapping,
         # "olmo-3-0625-7b-think": IndexMapping,
         # "olmo-3-0625-7b-instruct": IndexMapping,
         # "olmo-3-0625-32b-think": IndexMapping,
-        "olmo-3-0625-32b-instruct": IndexMapping,
+        # "olmo-3-0625-32b-instruct": IndexMapping,
     },
 )
 
 index_mappings: IndexMappings = {
-    # AvailableInfiniGramIndexId.PILEVAL_LLAMA.value: {
-    #     "tokenizer_factory": get_llama_2_tokenizer,
-    #     "index_dir": f"{tokenizer_config.index_base_path}/v4_pileval_llama",
-    #     "index_dir_diff": [],
-    #     "token_dtype": "u16",
-    # },
+    AvailableInfiniGramIndexId.PILEVAL_LLAMA.value: {
+        "tokenizer_factory": get_llama_2_tokenizer,
+        "index_dir": f"{tokenizer_config.index_base_path}/v4_pileval_llama",
+        "index_dir_diff": [],
+        "token_dtype": "u16",
+    },
     # AvailableInfiniGramIndexId.OLMOE_0125_1B_7B.value: {
     #     "tokenizer_factory": get_llama_2_tokenizer,
     #     "index_dir": [
@@ -73,16 +73,16 @@ index_mappings: IndexMappings = {
     #     "index_dir_diff": [],
     #     "token_dtype": "u16",
     # },
-    AvailableInfiniGramIndexId.OLMO_2_0325_32B.value: {
-        "tokenizer_factory": get_llama_2_tokenizer,
-        "index_dir": [
-            f"{tokenizer_config.index_base_path}/olmoe-mix-0924-dclm",
-            f"{tokenizer_config.index_base_path}/olmoe-mix-0924-nodclm",
-            f"{tokenizer_config.index_base_path}/v4-olmo-2-0325-32b-anneal-adapt",
-        ],
-        "index_dir_diff": [],
-        "token_dtype": "u16",
-    },
+    # AvailableInfiniGramIndexId.OLMO_2_0325_32B.value: {
+    #     "tokenizer_factory": get_llama_2_tokenizer,
+    #     "index_dir": [
+    #         f"{tokenizer_config.index_base_path}/olmoe-mix-0924-dclm",
+    #         f"{tokenizer_config.index_base_path}/olmoe-mix-0924-nodclm",
+    #         f"{tokenizer_config.index_base_path}/v4-olmo-2-0325-32b-anneal-adapt",
+    #     ],
+    #     "index_dir_diff": [],
+    #     "token_dtype": "u16",
+    # },
     # AvailableInfiniGramIndexId.TULU_3_8B.value: {
     #     "tokenizer_factory": get_llama_2_tokenizer,
     #     "index_dir": [
@@ -137,13 +137,13 @@ index_mappings: IndexMappings = {
     #     "index_dir_diff": [],
     #     "token_dtype": "u32",
     # },
-    AvailableInfiniGramIndexId.OLMO_3_0625_32B_INSTRUCT.value: {
-        "tokenizer_factory": get_dolma_2_tokenizer,
-        "index_dir": [
-            f"{tokenizer_config.index_base_path}/dolma2-0625-base-shared",
-            f"{tokenizer_config.index_base_path}/v6-dolma2-0625-v02-32b",
-        ],
-        "index_dir_diff": [],
-        "token_dtype": "u32",
-    },
+    # AvailableInfiniGramIndexId.OLMO_3_0625_32B_INSTRUCT.value: {
+    #     "tokenizer_factory": get_dolma_2_tokenizer,
+    #     "index_dir": [
+    #         f"{tokenizer_config.index_base_path}/dolma2-0625-base-shared",
+    #         f"{tokenizer_config.index_base_path}/v6-dolma2-0625-v02-32b",
+    #     ],
+    #     "index_dir_diff": [],
+    #     "token_dtype": "u32",
+    # },
 }

--- a/packages/infini-gram-processor/src/infini_gram_processor/models/camel_case_model.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/models/camel_case_model.py
@@ -2,7 +2,13 @@ from pydantic import BaseModel
 from pydantic.alias_generators import to_camel
 
 
-class CamelCaseModel(BaseModel):
+class CamelCaseConfigMixin:
     class Config:
         alias_generator = to_camel
         populate_by_name = True
+
+
+class CamelCaseModel(BaseModel, CamelCaseConfigMixin): ...
+
+
+class ApiRequest(BaseModel, CamelCaseConfigMixin, frozen=True): ...

--- a/packages/infini-gram-processor/src/infini_gram_processor/models/models.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/models/models.py
@@ -9,7 +9,17 @@ from infini_gram.models import (
 )
 from pydantic import BaseModel, Field
 
-from .camel_case_model import CamelCaseModel
+from .camel_case_model import ApiRequest, CamelCaseModel
+
+
+class CountRequest(ApiRequest, frozen=True):
+    query: str | list[int]
+
+
+class CountCnfRequest(ApiRequest, frozen=True):
+    query: str | list[list[list[int]]]
+    max_clause_freq: Optional[int] = None
+    max_diff_tokens: Optional[int] = None
 
 
 class GetDocumentByRankRequest(BaseModel):

--- a/packages/infini-gram-processor/src/infini_gram_processor/models/models.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/models/models.py
@@ -18,8 +18,8 @@ class CountRequest(ApiRequest, frozen=True):
 
 class CountCnfRequest(ApiRequest, frozen=True):
     query: str | list[list[list[int]]]
-    max_clause_freq: Optional[int] = None
-    max_diff_tokens: Optional[int] = None
+    max_clause_freq: int | None = Field(None, ge=1)
+    max_diff_tokens: int | None = Field(None, ge=1)
 
 
 class GetDocumentByRankRequest(BaseModel):

--- a/packages/infini-gram-processor/src/infini_gram_processor/models/models.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/models/models.py
@@ -54,9 +54,18 @@ class InfiniGramErrorResponse(CamelCaseModel):
     error: str
 
 
-class InfiniGramCountResponse(BaseInfiniGramResponse):
-    approx: bool
+class CountResponse(BaseInfiniGramResponse):
     count: int
+    approx: bool
+    token_ids: list[int]
+    tokens: list[str] | str
+
+
+class CountCnfResponse(BaseInfiniGramResponse):
+    count: int
+    approx: bool
+    token_ids: list[list[list[int]]]
+    tokens: list[list[list[str] | str]]
 
 
 class Document(CamelCaseModel):

--- a/packages/infini-gram-processor/src/infini_gram_processor/processor.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/processor.py
@@ -2,7 +2,6 @@ import json
 import logging
 from typing import (
     Iterable,
-    Optional,
     Sequence,
     cast,
 )
@@ -40,6 +39,9 @@ from .tokenizers.tokenizer import Tokenizer
 
 tracer = trace.get_tracer(__name__)
 logger = logging.getLogger("uvicorn.error")
+
+TokenizedCnfRequest = list[list[list[int]]]
+CnfTokens = list[list[list[str] | str]]
 
 
 class InfiniGramProcessor:
@@ -118,7 +120,7 @@ class InfiniGramProcessor:
 
     def validate_and_tokenize_query_cnf(
         self, query: str | list[list[list[int]]]
-    ) -> tuple[list[list[list[int]]], list[list[list[str] | str]]]:
+    ) -> tuple[TokenizedCnfRequest, CnfTokens]:
         # this function checks the upper limits, but doesn't check anything else
 
         if isinstance(query, str):
@@ -172,9 +174,9 @@ class InfiniGramProcessor:
     @tracer.start_as_current_span("infini_gram_processor/count_cnf")
     def count_cnf(
         self,
-        query: str | list[list[list[int]]],
-        max_clause_freq: Optional[int] = None,
-        max_diff_tokens: Optional[int] = None,
+        query: str | TokenizedCnfRequest,
+        max_clause_freq: int | None = None,
+        max_diff_tokens: int | None = None,
     ) -> CountCnfResponse:
         if max_clause_freq is not None and not (
             1 <= max_clause_freq <= tokenizer_config.max_clause_freq

--- a/packages/infini-gram-processor/src/infini_gram_processor/processor.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/processor.py
@@ -33,6 +33,7 @@ from .models.is_infini_gram_error_response import (
     TInfiniGramResponse,
     is_infini_gram_error_response,
 )
+from .processor_config import tokenizer_config
 from .tokenizers.tokenizer import Tokenizer
 
 tracer = trace.get_tracer(__name__)
@@ -94,6 +95,65 @@ class InfiniGramProcessor:
             raise exception
 
         return cast(TInfiniGramResponse, result)
+
+    def validate_and_tokenize_query(
+        self, query: str | list[int]
+    ) -> tuple[list[int], list[str] | str]:
+        # this function checks the upper limits, but doesn't check anything else
+
+        if isinstance(query, str):
+            if len(query) > tokenizer_config.MAX_QUERY_CHARS:
+                raise InfiniGramEngineException(
+                    detail=f"Please limit your input to <= {tokenizer_config.MAX_QUERY_CHARS} characters!"
+                )
+            query_ids = self.tokenize(query)
+        else:
+            query_ids = query
+
+        tokens = self.tokenizer.hf_tokenizer.convert_ids_to_tokens(query_ids)
+
+        return query_ids, tokens
+
+    def validate_and_tokenize_query_cnf(
+        self, query: str | list[list[list[int]]]
+    ) -> tuple[list[list[list[int]]], list[list[list[str] | str]]]:
+        # this function checks the upper limits, but doesn't check anything else
+
+        if isinstance(query, str):
+            if len(query) > tokenizer_config.MAX_QUERY_CHARS:
+                raise InfiniGramEngineException(
+                    detail=f"Please limit your input to <= {tokenizer_config.MAX_QUERY_CHARS} characters!"
+                )
+            cnf = [
+                [self.tokenize(term) for term in clause.split(" OR ")]
+                for clause in query.split(" AND ")
+            ]
+        else:
+            cnf = query
+
+        if (
+            sum(sum(len(term) for term in clause) for clause in cnf)
+            > tokenizer_config.MAX_QUERY_TOKENS
+        ):
+            raise InfiniGramEngineException(
+                detail=f"Please limit your input to <= {tokenizer_config.MAX_QUERY_TOKENS} tokens!"
+            )
+        if len(cnf) > tokenizer_config.MAX_CLAUSES_PER_CNF:
+            raise InfiniGramEngineException(
+                detail=f"Please enter at most {tokenizer_config.MAX_CLAUSES_PER_CNF} disjunctive clauses!"
+            )
+        for clause in cnf:
+            if len(clause) > tokenizer_config.MAX_TERMS_PER_CLAUSE:
+                raise InfiniGramEngineException(
+                    detail=f"Please enter at most {tokenizer_config.MAX_TERMS_PER_CLAUSE} terms in each disjunctive clause!"
+                )
+
+        tokens = [
+            [self.tokenizer.hf_tokenizer.convert_ids_to_tokens(term) for term in clause]
+            for clause in cnf
+        ]
+
+        return cnf, tokens
 
     @tracer.start_as_current_span("infini_gram_processor/count_n_gram")
     def count_n_gram(self, query: str) -> InfiniGramCountResponse:

--- a/packages/infini-gram-processor/src/infini_gram_processor/processor.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/processor.py
@@ -104,9 +104,9 @@ class InfiniGramProcessor:
         # this function checks the upper limits, but doesn't check anything else
 
         if isinstance(query, str):
-            if len(query) > tokenizer_config.MAX_QUERY_CHARS:
+            if len(query) > tokenizer_config.max_query_chars:
                 raise InfiniGramEngineException(
-                    detail=f"Please limit your input to <= {tokenizer_config.MAX_QUERY_CHARS} characters!"
+                    detail=f"Please limit your input to <= {tokenizer_config.max_query_chars} characters!"
                 )
             query_ids = self.tokenize(query)
         else:
@@ -122,9 +122,9 @@ class InfiniGramProcessor:
         # this function checks the upper limits, but doesn't check anything else
 
         if isinstance(query, str):
-            if len(query) > tokenizer_config.MAX_QUERY_CHARS:
+            if len(query) > tokenizer_config.max_query_chars:
                 raise InfiniGramEngineException(
-                    detail=f"Please limit your input to <= {tokenizer_config.MAX_QUERY_CHARS} characters!"
+                    detail=f"Please limit your input to <= {tokenizer_config.max_query_chars} characters!"
                 )
             cnf = [
                 [self.tokenize(term) for term in clause.split(" OR ")]
@@ -135,19 +135,19 @@ class InfiniGramProcessor:
 
         if (
             sum(sum(len(term) for term in clause) for clause in cnf)
-            > tokenizer_config.MAX_QUERY_TOKENS
+            > tokenizer_config.max_query_tokens
         ):
             raise InfiniGramEngineException(
-                detail=f"Please limit your input to <= {tokenizer_config.MAX_QUERY_TOKENS} tokens!"
+                detail=f"Please limit your input to <= {tokenizer_config.max_query_tokens} tokens!"
             )
-        if len(cnf) > tokenizer_config.MAX_CLAUSES_PER_CNF:
+        if len(cnf) > tokenizer_config.max_clauses_per_cnf:
             raise InfiniGramEngineException(
-                detail=f"Please enter at most {tokenizer_config.MAX_CLAUSES_PER_CNF} disjunctive clauses!"
+                detail=f"Please enter at most {tokenizer_config.max_clauses_per_cnf} disjunctive clauses!"
             )
         for clause in cnf:
-            if len(clause) > tokenizer_config.MAX_TERMS_PER_CLAUSE:
+            if len(clause) > tokenizer_config.max_terms_per_clause:
                 raise InfiniGramEngineException(
-                    detail=f"Please enter at most {tokenizer_config.MAX_TERMS_PER_CLAUSE} terms in each disjunctive clause!"
+                    detail=f"Please enter at most {tokenizer_config.max_terms_per_clause} terms in each disjunctive clause!"
                 )
 
         tokens = [
@@ -177,16 +177,16 @@ class InfiniGramProcessor:
         max_diff_tokens: Optional[int] = None,
     ) -> CountCnfResponse:
         if max_clause_freq is not None and not (
-            1 <= max_clause_freq <= tokenizer_config.MAX_CLAUSE_FREQ
+            1 <= max_clause_freq <= tokenizer_config.max_clause_freq
         ):
             raise InfiniGramEngineException(
-                detail=f"max_clause_freq must be an integer in [1, {tokenizer_config.MAX_CLAUSE_FREQ}]!"
+                detail=f"max_clause_freq must be an integer in [1, {tokenizer_config.max_clause_freq}]!"
             )
         if max_diff_tokens is not None and not (
-            1 <= max_diff_tokens <= tokenizer_config.MAX_DIFF_TOKENS
+            1 <= max_diff_tokens <= tokenizer_config.max_diff_tokens
         ):
             raise InfiniGramEngineException(
-                detail=f"max_diff_tokens must be an integer in [1, {tokenizer_config.MAX_DIFF_TOKENS}]!"
+                detail=f"max_diff_tokens must be an integer in [1, {tokenizer_config.max_diff_tokens}]!"
             )
 
         cnf, tokens = self.validate_and_tokenize_query_cnf(query)

--- a/packages/infini-gram-processor/src/infini_gram_processor/processor.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/processor.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import (
     Iterable,
+    Optional,
     Sequence,
     cast,
 )
@@ -18,6 +19,8 @@ from transformers.tokenization_utils_base import (
     TextInput,
 )
 
+from infini_gram_processor.models.models import CountCnfResponse, CountResponse
+
 from .index_mappings import AvailableInfiniGramIndexId, index_mappings
 from .infini_gram_engine_exception import InfiniGramEngineException
 from .models import (
@@ -26,7 +29,6 @@ from .models import (
     GetDocumentByPointerRequest,
     GetDocumentByRankRequest,
     InfiniGramAttributionResponse,
-    InfiniGramCountResponse,
     InfiniGramSearchResponse,
 )
 from .models.is_infini_gram_error_response import (
@@ -155,15 +157,49 @@ class InfiniGramProcessor:
 
         return cnf, tokens
 
-    @tracer.start_as_current_span("infini_gram_processor/count_n_gram")
-    def count_n_gram(self, query: str) -> InfiniGramCountResponse:
-        tokenized_query_ids = self.tokenize(query)
+    @tracer.start_as_current_span("infini_gram_processor/count")
+    def count(self, query: str | list[int]) -> CountResponse:
+        query_ids, tokens = self.validate_and_tokenize_query(query)
 
-        count_response = self.infini_gram_engine.count(input_ids=tokenized_query_ids)
+        count_response = self.infini_gram_engine.count(input_ids=query_ids)
 
         count_result = self.__handle_error(count_response)
 
-        return InfiniGramCountResponse(index=self.index, **count_result)
+        return CountResponse(
+            index=self.index, token_ids=query_ids, tokens=tokens, **count_result
+        )
+
+    @tracer.start_as_current_span("infini_gram_processor/count_cnf")
+    def count_cnf(
+        self,
+        query: str | list[list[list[int]]],
+        max_clause_freq: Optional[int] = None,
+        max_diff_tokens: Optional[int] = None,
+    ) -> CountCnfResponse:
+        if max_clause_freq is not None and not (
+            1 <= max_clause_freq <= tokenizer_config.MAX_CLAUSE_FREQ
+        ):
+            raise InfiniGramEngineException(
+                detail=f"max_clause_freq must be an integer in [1, {tokenizer_config.MAX_CLAUSE_FREQ}]!"
+            )
+        if max_diff_tokens is not None and not (
+            1 <= max_diff_tokens <= tokenizer_config.MAX_DIFF_TOKENS
+        ):
+            raise InfiniGramEngineException(
+                detail=f"max_diff_tokens must be an integer in [1, {tokenizer_config.MAX_DIFF_TOKENS}]!"
+            )
+
+        cnf, tokens = self.validate_and_tokenize_query_cnf(query)
+
+        count_cnf_response = self.infini_gram_engine.count_cnf(
+            cnf=cnf, max_clause_freq=max_clause_freq, max_diff_tokens=max_diff_tokens
+        )
+
+        count_cnf_result = self.__handle_error(count_cnf_response)
+
+        return CountCnfResponse(
+            index=self.index, token_ids=cnf, tokens=tokens, **count_cnf_result
+        )
 
     @tracer.start_as_current_span("infini_gram_processor/get_document_by_rank")
     def get_document_by_rank(

--- a/packages/infini-gram-processor/src/infini_gram_processor/processor_config.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/processor_config.py
@@ -7,6 +7,14 @@ class ProcessorConfig(BaseSettings):
     index_base_path: str = "/mnt/infinigram-array"
     vendor_base_path: str = "/app/vendor"
 
+    MAX_QUERY_CHARS = 1000
+    MAX_QUERY_TOKENS = 500
+    MAX_CLAUSES_PER_CNF = 4
+    MAX_TERMS_PER_CLAUSE = 4
+    MAX_SUPPORT = 10000
+    MAX_CLAUSE_FREQ = 500000
+    MAX_DIFF_TOKENS = 1000
+
 
 tokenizer_config = ProcessorConfig()
 

--- a/packages/infini-gram-processor/src/infini_gram_processor/processor_config.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/processor_config.py
@@ -7,13 +7,13 @@ class ProcessorConfig(BaseSettings):
     index_base_path: str = "/mnt/infinigram-array"
     vendor_base_path: str = "/app/vendor"
 
-    MAX_QUERY_CHARS = 1000
-    MAX_QUERY_TOKENS = 500
-    MAX_CLAUSES_PER_CNF = 4
-    MAX_TERMS_PER_CLAUSE = 4
-    MAX_SUPPORT = 10000
-    MAX_CLAUSE_FREQ = 500000
-    MAX_DIFF_TOKENS = 1000
+    max_query_chars: int = 1000
+    max_query_tokens: int = 500
+    max_clauses_per_cnf: int = 4
+    max_terms_per_clause: int = 4
+    max_support: int = 10000
+    max_clause_freq: int = 500000
+    max_diff_tokens: int = 1000
 
 
 tokenizer_config = ProcessorConfig()

--- a/packages/infinigram-api-shared/src/infinigram_api_shared/saq/queue_utils.py
+++ b/packages/infinigram-api-shared/src/infinigram_api_shared/saq/queue_utils.py
@@ -1,13 +1,18 @@
+from enum import StrEnum
 from functools import lru_cache
 
 from infini_gram_processor.index_mappings import AvailableInfiniGramIndexId
 from saq import Queue
 
-_BASE_JOB_NAME = "attribute"
+
+class Jobs(StrEnum):
+    ATTRIBUTE = "attribute"
+    COUNT = "count"
+    COUNT_CNF = "count_cnf"
 
 
 def get_attribute_job_name_for_index(index_id: AvailableInfiniGramIndexId) -> str:
-    return _BASE_JOB_NAME
+    return Jobs.ATTRIBUTE
 
 
 def get_queue_name(index_id: AvailableInfiniGramIndexId, base_queue_name: str) -> str:


### PR DESCRIPTION
Note: not tested yet! Need to remember how to run this locally without huge indexes.

This PR adds the `count` and `count_cnf` functionality back to this API. It uses https://github.com/allenai/infinigram-api/pull/108 as a reference for how to implement those functions into the `InfiniGramProcessor`. This PR uses workers instead of accessing the index in the API.