### PR TITLE
Fix attribution response parsing, use the right CountResponse

### DIFF
--- a/api/src/infinigram/count_service.py
+++ b/api/src/infinigram/count_service.py
@@ -7,22 +7,17 @@ from infini_gram_processor.models.models import (
     CountCnfRequest,
     CountCnfResponse,
     CountRequest,
+    CountResponse,
 )
 from infinigram_api_shared.saq.queue_utils import Jobs
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
 from src.attribution.attribution_service import AttributionTimeoutError
-from src.camel_case_model import CamelCaseModel
 from src.queue_service import abort_job, publish_job
 
 tracer = trace.get_tracer(__name__)
 logger = logging.getLogger("uvicorn.error")
-
-
-class CountResponse(CamelCaseModel):
-    approx: bool
-    count: int
 
 
 class CountService:

--- a/api/src/infinigram/infinigram_router.py
+++ b/api/src/infinigram/infinigram_router.py
@@ -4,9 +4,10 @@ from infini_gram_processor.models.models import (
     CountCnfRequest,
     CountCnfResponse,
     CountRequest,
+    CountResponse,
 )
 
-from src.infinigram.count_service import CountResponse, CountServiceDependency
+from src.infinigram.count_service import CountServiceDependency
 
 infinigram_router = APIRouter()
 

--- a/packages/infini-gram-processor/src/infini_gram_processor/models/camel_case_model.py
+++ b/packages/infini-gram-processor/src/infini_gram_processor/models/camel_case_model.py
@@ -2,13 +2,13 @@ from pydantic import BaseModel
 from pydantic.alias_generators import to_camel
 
 
-class CamelCaseConfigMixin:
+class CamelCaseModel(BaseModel):
     class Config:
         alias_generator = to_camel
         populate_by_name = True
 
 
-class CamelCaseModel(BaseModel, CamelCaseConfigMixin): ...
-
-
-class ApiRequest(BaseModel, CamelCaseConfigMixin, frozen=True): ...
+class ApiRequest(BaseModel, frozen=True):
+    class Config:
+        alias_generator = to_camel
+        populate_by_name = True


### PR DESCRIPTION
I think I didn't test the `CamelCaseMixin` well enough. Attribution responses were breaking in prod. Fixed by just copying the config, we can remove duplication later if we want.

I also used the wrong response model for `CountResponse`, so this PR fixes that as well.